### PR TITLE
chore: update mulmocast to 2.1.34

### DIFF
--- a/packages/mulmocast-easy/package.json
+++ b/packages/mulmocast-easy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-easy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MulmoCast with bundled ffmpeg for easy installation",
   "type": "module",
   "main": "lib/index.js",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
-    "mulmocast": "^2.1.33",
-    "ffmpeg-ffprobe-static": "^6.1.2-rc.1"
+    "ffmpeg-ffprobe-static": "^6.1.2-rc.1",
+    "mulmocast": "^2.1.34"
   }
 }


### PR DESCRIPTION
## Summary

- Update mulmocast dependency to ^2.1.34 (cliMain fix)
- Bump mulmocast-easy version to 0.0.2

## Changes

mulmocast 2.1.34 separates `cliMain` function to prevent auto-execution on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)