### PR TITLE
feat(preprocessor): implement core variant and filter API

### DIFF
--- a/packages/mulmocast-preprocessor/README.md
+++ b/packages/mulmocast-preprocessor/README.md
@@ -1,0 +1,137 @@
+# mulmocast-preprocessor
+
+Preprocessor for MulmoScript that enables generating multiple variations (full, summary, teaser, etc.) from a single script.
+
+## Installation
+
+```bash
+npm install mulmocast-preprocessor
+```
+
+## Features
+
+- **Profile-based variants**: Generate different versions (summary, teaser) from one script
+- **Section filtering**: Extract beats by section
+- **Tag filtering**: Extract beats by tags
+- **Profile listing**: List available profiles with beat counts
+
+## Usage
+
+### Basic Example
+
+```typescript
+import { processScript, listProfiles, applyProfile } from "mulmocast-preprocessor";
+import type { ExtendedScript } from "mulmocast-preprocessor";
+
+const script: ExtendedScript = {
+  title: "My Presentation",
+  beats: [
+    {
+      text: "Full introduction text here...",
+      variants: {
+        summary: { text: "Brief intro" },
+        teaser: { skip: true }
+      },
+      meta: { section: "intro", tags: ["important"] }
+    },
+    {
+      text: "Main content...",
+      meta: { section: "main", tags: ["core"] }
+    }
+  ]
+};
+
+// List available profiles
+const profiles = listProfiles(script);
+// [{ name: "default", beatCount: 2 }, { name: "summary", beatCount: 2 }, { name: "teaser", beatCount: 1, skippedCount: 1 }]
+
+// Generate summary version
+const summary = applyProfile(script, "summary");
+// First beat's text is replaced with "Brief intro"
+
+// Process with multiple options
+const result = processScript(script, {
+  profile: "summary",
+  section: "intro"
+});
+```
+
+## API
+
+### `processScript(script, options)`
+
+Main processing function that applies profile and filters.
+
+**Parameters:**
+- `script: ExtendedScript` - Input script with variants/meta
+- `options: ProcessOptions` - Processing options
+  - `profile?: string` - Profile name to apply
+  - `section?: string` - Filter by section
+  - `tags?: string[]` - Filter by tags (OR logic)
+
+**Returns:** `MulmoScript` - Standard MulmoScript with variants/meta stripped
+
+### `applyProfile(script, profileName)`
+
+Apply a profile to the script, replacing text/image and skipping marked beats.
+
+**Parameters:**
+- `script: ExtendedScript` - Input script
+- `profileName: string` - Profile name
+
+**Returns:** `MulmoScript` - Processed script
+
+### `listProfiles(script)`
+
+Get list of available profiles from script.
+
+**Parameters:**
+- `script: ExtendedScript` - Input script
+
+**Returns:** `ProfileInfo[]` - Array of profile info with beat counts
+
+### `filterBySection(script, section)`
+
+Filter beats by section.
+
+### `filterByTags(script, tags)`
+
+Filter beats by tags (extracts beats that have any of the specified tags).
+
+## Extended Schema
+
+### ExtendedBeat
+
+```typescript
+interface ExtendedBeat extends MulmoBeat {
+  variants?: Record<string, BeatVariant>;
+  meta?: BeatMeta;
+}
+```
+
+### BeatVariant
+
+```typescript
+interface BeatVariant {
+  text?: string;       // Override text
+  skip?: boolean;      // Skip this beat
+  image?: MulmoImage;  // Override image
+  imagePrompt?: string; // Override imagePrompt
+}
+```
+
+### BeatMeta
+
+```typescript
+interface BeatMeta {
+  tags?: string[];
+  section?: string;
+  context?: string;
+  keywords?: string[];
+  expectedQuestions?: string[];
+}
+```
+
+## License
+
+MIT

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "lint": "eslint src",
     "format": "prettier --write 'src/**/*.ts'",
-    "test": "echo 'no tests yet'"
+    "test": "node --import tsx --test test/*.ts"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
-    "mulmocast": "^2.1.35"
+    "mulmocast": "^2.1.35",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/mulmocast-preprocessor/src/actions/index.ts
+++ b/packages/mulmocast-preprocessor/src/actions/index.ts
@@ -1,3 +1,0 @@
-// Preprocessor actions
-// TODO: implement preprocessor functionality
-export const preprocessorVersion = "0.0.1";

--- a/packages/mulmocast-preprocessor/src/core/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/filter.ts
@@ -6,34 +6,28 @@ const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
   return baseBeat;
 };
 
-const stripScriptExtendedFields = <T extends ExtendedScript>(script: T, beats: MulmoBeat[]): MulmoScript => {
+const filterBeats = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): MulmoScript => {
   const { outputProfiles: __outputProfiles, ...baseScript } = script;
-  return { ...baseScript, beats } as MulmoScript;
+  return {
+    ...baseScript,
+    beats: script.beats.filter(predicate).map(stripBeatExtendedFields),
+  } as MulmoScript;
 };
 
 /**
  * セクションでフィルタ
  */
-export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => {
-  const filteredBeats = script.beats.filter((beat) => beat.meta?.section === section).map(stripBeatExtendedFields);
-
-  return stripScriptExtendedFields(script, filteredBeats);
-};
+export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => filterBeats(script, (beat) => beat.meta?.section === section);
 
 /**
  * タグでフィルタ（指定されたタグのいずれかを持つbeatを抽出）
  */
 export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScript => {
   const tagSet = new Set(tags);
-
-  const filteredBeats = script.beats.filter((beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag))).map(stripBeatExtendedFields);
-
-  return stripScriptExtendedFields(script, filteredBeats);
+  return filterBeats(script, (beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag)));
 };
 
 /**
  * variants と meta を除去して通常のMulmoScriptに変換
  */
-export const stripExtendedFields = (script: ExtendedScript): MulmoScript => {
-  return stripScriptExtendedFields(script, script.beats.map(stripBeatExtendedFields));
-};
+export const stripExtendedFields = (script: ExtendedScript): MulmoScript => filterBeats(script, () => true);

--- a/packages/mulmocast-preprocessor/src/core/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/filter.ts
@@ -1,25 +1,23 @@
 import type { MulmoScript, MulmoBeat } from "mulmocast";
 import type { ExtendedScript, ExtendedBeat } from "../types/index.js";
 
+const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
+  const { variants: __variants, meta: __meta, ...baseBeat } = beat;
+  return baseBeat;
+};
+
+const stripScriptExtendedFields = <T extends ExtendedScript>(script: T, beats: MulmoBeat[]): MulmoScript => {
+  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+  return { ...baseScript, beats } as MulmoScript;
+};
+
 /**
  * セクションでフィルタ
  */
 export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => {
-  const filteredBeats: MulmoBeat[] = [];
+  const filteredBeats = script.beats.filter((beat) => beat.meta?.section === section).map(stripBeatExtendedFields);
 
-  for (const beat of script.beats) {
-    if (beat.meta?.section === section) {
-      const { variants: __variants, meta: __meta, ...baseBeat } = beat;
-      filteredBeats.push(baseBeat);
-    }
-  }
-
-  const { outputProfiles: __outputProfiles, ...baseScript } = script;
-
-  return {
-    ...baseScript,
-    beats: filteredBeats,
-  } as MulmoScript;
+  return stripScriptExtendedFields(script, filteredBeats);
 };
 
 /**
@@ -27,39 +25,15 @@ export const filterBySection = (script: ExtendedScript, section: string): MulmoS
  */
 export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScript => {
   const tagSet = new Set(tags);
-  const filteredBeats: MulmoBeat[] = [];
 
-  for (const beat of script.beats) {
-    const beatTags = beat.meta?.tags ?? [];
-    const hasMatchingTag = beatTags.some((tag) => tagSet.has(tag));
+  const filteredBeats = script.beats.filter((beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag))).map(stripBeatExtendedFields);
 
-    if (hasMatchingTag) {
-      const { variants: __variants, meta: __meta, ...baseBeat } = beat;
-      filteredBeats.push(baseBeat);
-    }
-  }
-
-  const { outputProfiles: __outputProfiles, ...baseScript } = script;
-
-  return {
-    ...baseScript,
-    beats: filteredBeats,
-  } as MulmoScript;
+  return stripScriptExtendedFields(script, filteredBeats);
 };
 
 /**
  * variants と meta を除去して通常のMulmoScriptに変換
  */
 export const stripExtendedFields = (script: ExtendedScript): MulmoScript => {
-  const cleanedBeats: MulmoBeat[] = script.beats.map((beat: ExtendedBeat) => {
-    const { variants: __variants, meta: __meta, ...baseBeat } = beat;
-    return baseBeat;
-  });
-
-  const { outputProfiles: __outputProfiles, ...baseScript } = script;
-
-  return {
-    ...baseScript,
-    beats: cleanedBeats,
-  } as MulmoScript;
+  return stripScriptExtendedFields(script, script.beats.map(stripBeatExtendedFields));
 };

--- a/packages/mulmocast-preprocessor/src/core/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/filter.ts
@@ -1,0 +1,65 @@
+import type { MulmoScript, MulmoBeat } from "mulmocast";
+import type { ExtendedScript, ExtendedBeat } from "../types/index.js";
+
+/**
+ * セクションでフィルタ
+ */
+export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => {
+  const filteredBeats: MulmoBeat[] = [];
+
+  for (const beat of script.beats) {
+    if (beat.meta?.section === section) {
+      const { variants: __variants, meta: __meta, ...baseBeat } = beat;
+      filteredBeats.push(baseBeat);
+    }
+  }
+
+  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+
+  return {
+    ...baseScript,
+    beats: filteredBeats,
+  } as MulmoScript;
+};
+
+/**
+ * タグでフィルタ（指定されたタグのいずれかを持つbeatを抽出）
+ */
+export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScript => {
+  const tagSet = new Set(tags);
+  const filteredBeats: MulmoBeat[] = [];
+
+  for (const beat of script.beats) {
+    const beatTags = beat.meta?.tags ?? [];
+    const hasMatchingTag = beatTags.some((tag) => tagSet.has(tag));
+
+    if (hasMatchingTag) {
+      const { variants: __variants, meta: __meta, ...baseBeat } = beat;
+      filteredBeats.push(baseBeat);
+    }
+  }
+
+  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+
+  return {
+    ...baseScript,
+    beats: filteredBeats,
+  } as MulmoScript;
+};
+
+/**
+ * variants と meta を除去して通常のMulmoScriptに変換
+ */
+export const stripExtendedFields = (script: ExtendedScript): MulmoScript => {
+  const cleanedBeats: MulmoBeat[] = script.beats.map((beat: ExtendedBeat) => {
+    const { variants: __variants, meta: __meta, ...baseBeat } = beat;
+    return baseBeat;
+  });
+
+  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+
+  return {
+    ...baseScript,
+    beats: cleanedBeats,
+  } as MulmoScript;
+};

--- a/packages/mulmocast-preprocessor/src/core/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/filter.ts
@@ -15,12 +15,12 @@ const filterBeats = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => 
 };
 
 /**
- * セクションでフィルタ
+ * Filter beats by section
  */
 export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => filterBeats(script, (beat) => beat.meta?.section === section);
 
 /**
- * タグでフィルタ（指定されたタグのいずれかを持つbeatを抽出）
+ * Filter beats by tags (extract beats that have any of the specified tags)
  */
 export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScript => {
   const tagSet = new Set(tags);
@@ -28,6 +28,6 @@ export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScrip
 };
 
 /**
- * variants と meta を除去して通常のMulmoScriptに変換
+ * Strip variants and meta fields, converting to standard MulmoScript
  */
 export const stripExtendedFields = (script: ExtendedScript): MulmoScript => filterBeats(script, () => true);

--- a/packages/mulmocast-preprocessor/src/core/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/process.ts
@@ -9,8 +9,8 @@ const toExtendedScript = (script: MulmoScript): ExtendedScript => ({
 });
 
 /**
- * メイン処理関数
- * プロファイル適用とフィルタを一括実行
+ * Main processing function
+ * Applies profile and filters in a single call
  */
 export const processScript = (script: ExtendedScript, options: ProcessOptions = {}): MulmoScript => {
   const afterProfile = options.profile && options.profile !== "default" ? applyProfile(script, options.profile) : stripExtendedFields(script);

--- a/packages/mulmocast-preprocessor/src/core/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/process.ts
@@ -1,0 +1,36 @@
+import type { MulmoScript } from "mulmocast";
+import type { ExtendedScript, ProcessOptions } from "../types/index.js";
+import { applyProfile } from "./variant.js";
+import { filterBySection, filterByTags, stripExtendedFields } from "./filter.js";
+
+/**
+ * メイン処理関数
+ * プロファイル適用とフィルタを一括実行
+ */
+export const processScript = (script: ExtendedScript, options: ProcessOptions = {}): MulmoScript => {
+  let result: MulmoScript;
+
+  if (options.profile && options.profile !== "default") {
+    result = applyProfile(script, options.profile);
+  } else {
+    result = stripExtendedFields(script);
+  }
+
+  if (options.section) {
+    const extendedResult: ExtendedScript = {
+      ...result,
+      beats: result.beats.map((beat) => ({ ...beat })),
+    };
+    result = filterBySection(extendedResult, options.section);
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    const extendedResult: ExtendedScript = {
+      ...result,
+      beats: result.beats.map((beat) => ({ ...beat })),
+    };
+    result = filterByTags(extendedResult, options.tags);
+  }
+
+  return result;
+};

--- a/packages/mulmocast-preprocessor/src/core/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/core/profiles.ts
@@ -1,0 +1,56 @@
+import type { ExtendedScript, ProfileInfo } from "../types/index.js";
+
+/**
+ * スクリプトからプロファイル一覧を取得
+ */
+export const listProfiles = (script: ExtendedScript): ProfileInfo[] => {
+  const profiles: ProfileInfo[] = [];
+  const profileNames = new Set<string>();
+
+  profileNames.add("default");
+
+  for (const beat of script.beats) {
+    if (beat.variants) {
+      for (const profileName of Object.keys(beat.variants)) {
+        profileNames.add(profileName);
+      }
+    }
+  }
+
+  for (const profileName of profileNames) {
+    const outputProfile = script.outputProfiles?.[profileName];
+
+    let beatCount = 0;
+    let skippedCount = 0;
+
+    for (const beat of script.beats) {
+      const variant = beat.variants?.[profileName];
+      if (variant?.skip) {
+        skippedCount++;
+      } else {
+        beatCount++;
+      }
+    }
+
+    if (profileName === "default") {
+      beatCount = script.beats.length;
+      skippedCount = 0;
+    }
+
+    profiles.push({
+      name: profileName,
+      displayName: outputProfile?.name,
+      description: outputProfile?.description,
+      beatCount,
+      skippedCount,
+    });
+  }
+
+  profiles.sort((a, b) => {
+    if (a.name === "default") return -1;
+    if (b.name === "default") return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  return profiles;
+};

--- a/packages/mulmocast-preprocessor/src/core/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/core/profiles.ts
@@ -1,7 +1,7 @@
 import type { ExtendedScript, ProfileInfo } from "../types/index.js";
 
 /**
- * スクリプトからプロファイル一覧を取得
+ * Get list of available profiles from script
  */
 export const listProfiles = (script: ExtendedScript): ProfileInfo[] => {
   const profileNames = new Set<string>(["default"]);

--- a/packages/mulmocast-preprocessor/src/core/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/variant.ts
@@ -1,0 +1,57 @@
+import type { MulmoScript, MulmoBeat } from "mulmocast";
+import type { ExtendedScript, ExtendedBeat } from "../types/index.js";
+
+/**
+ * 単一のbeatにプロファイルを適用する
+ * @returns 処理済みbeat、またはskipの場合はnull
+ */
+const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat | null => {
+  const variant = beat.variants?.[profileName];
+
+  if (variant?.skip) {
+    return null;
+  }
+
+  const { variants: __variants, meta: __meta, ...baseBeat } = beat;
+
+  if (!variant) {
+    return baseBeat;
+  }
+
+  const result: MulmoBeat = { ...baseBeat };
+
+  if (variant.text !== undefined) {
+    result.text = variant.text;
+  }
+
+  if (variant.image !== undefined) {
+    result.image = variant.image;
+  }
+
+  if (variant.imagePrompt !== undefined) {
+    result.imagePrompt = variant.imagePrompt;
+  }
+
+  return result;
+};
+
+/**
+ * スクリプトにプロファイルを適用し、通常のMulmoScriptを返す
+ */
+export const applyProfile = (script: ExtendedScript, profileName: string): MulmoScript => {
+  const processedBeats: MulmoBeat[] = [];
+
+  for (const beat of script.beats) {
+    const processed = applyVariantToBeat(beat, profileName);
+    if (processed !== null) {
+      processedBeats.push(processed);
+    }
+  }
+
+  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+
+  return {
+    ...baseScript,
+    beats: processedBeats,
+  } as MulmoScript;
+};

--- a/packages/mulmocast-preprocessor/src/core/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/variant.ts
@@ -2,8 +2,8 @@ import type { MulmoScript, MulmoBeat } from "mulmocast";
 import type { ExtendedScript, ExtendedBeat } from "../types/index.js";
 
 /**
- * 単一のbeatにプロファイルを適用する
- * @returns 処理済みbeat、またはskipの場合はnull
+ * Apply profile variant to a single beat
+ * @returns Processed beat, or null if skip is set
  */
 const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat | null => {
   const variant = beat.variants?.[profileName];
@@ -23,7 +23,7 @@ const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat 
 };
 
 /**
- * スクリプトにプロファイルを適用し、通常のMulmoScriptを返す
+ * Apply profile to script and return standard MulmoScript
  */
 export const applyProfile = (script: ExtendedScript, profileName: string): MulmoScript => {
   const { outputProfiles: __outputProfiles, ...baseScript } = script;

--- a/packages/mulmocast-preprocessor/src/core/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/variant.ts
@@ -18,40 +18,18 @@ const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat 
     return baseBeat;
   }
 
-  const result: MulmoBeat = { ...baseBeat };
-
-  if (variant.text !== undefined) {
-    result.text = variant.text;
-  }
-
-  if (variant.image !== undefined) {
-    result.image = variant.image;
-  }
-
-  if (variant.imagePrompt !== undefined) {
-    result.imagePrompt = variant.imagePrompt;
-  }
-
-  return result;
+  const { skip: __skip, ...overrides } = variant;
+  return { ...baseBeat, ...overrides };
 };
 
 /**
  * スクリプトにプロファイルを適用し、通常のMulmoScriptを返す
  */
 export const applyProfile = (script: ExtendedScript, profileName: string): MulmoScript => {
-  const processedBeats: MulmoBeat[] = [];
-
-  for (const beat of script.beats) {
-    const processed = applyVariantToBeat(beat, profileName);
-    if (processed !== null) {
-      processedBeats.push(processed);
-    }
-  }
-
   const { outputProfiles: __outputProfiles, ...baseScript } = script;
 
   return {
     ...baseScript,
-    beats: processedBeats,
+    beats: script.beats.map((beat) => applyVariantToBeat(beat, profileName)).filter((beat): beat is MulmoBeat => beat !== null),
   } as MulmoScript;
 };

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -1,1 +1,11 @@
-export * from "./actions/index.js";
+// Core API
+export { processScript } from "./core/process.js";
+export { applyProfile } from "./core/variant.js";
+export { filterBySection, filterByTags, stripExtendedFields } from "./core/filter.js";
+export { listProfiles } from "./core/profiles.js";
+
+// Types
+export type { BeatVariant, BeatMeta, ExtendedBeat, ExtendedScript, OutputProfile, ProcessOptions, ProfileInfo } from "./types/index.js";
+
+// Schemas (for validation)
+export { beatVariantSchema, beatMetaSchema, extendedBeatSchema, extendedScriptSchema, outputProfileSchema } from "./types/index.js";

--- a/packages/mulmocast-preprocessor/src/types/index.ts
+++ b/packages/mulmocast-preprocessor/src/types/index.ts
@@ -1,25 +1,22 @@
 import { z } from "zod";
-import { mulmoBeatSchema, mulmoScriptSchema, type MulmoBeat } from "mulmocast";
+import { mulmoBeatSchema, mulmoScriptSchema, mulmoImageAssetSchema } from "mulmocast";
+
+export type { MulmoImageAsset } from "mulmocast";
 
 /**
- * MulmoBeat の image フィールドの型を取得
- */
-export type MulmoImage = MulmoBeat["image"];
-
-/**
- * Beat Variant - プロファイル別の差し替え定義
+ * Beat Variant - profile-specific content overrides
  */
 export const beatVariantSchema = z.object({
   text: z.string().optional(),
   skip: z.boolean().optional(),
-  image: z.any().optional(), // MulmoImage type at runtime
+  image: mulmoImageAssetSchema.optional(),
   imagePrompt: z.string().optional(),
 });
 
 export type BeatVariant = z.infer<typeof beatVariantSchema>;
 
 /**
- * Beat Meta - beatのメタデータ
+ * Beat Meta - metadata for filtering and context
  */
 export const beatMetaSchema = z.object({
   tags: z.array(z.string()).optional(),
@@ -32,7 +29,7 @@ export const beatMetaSchema = z.object({
 export type BeatMeta = z.infer<typeof beatMetaSchema>;
 
 /**
- * Extended Beat - variants と meta を持つ拡張beat
+ * Extended Beat - beat with variants and meta fields
  */
 export const extendedBeatSchema = mulmoBeatSchema.extend({
   variants: z.record(z.string(), beatVariantSchema).optional(),
@@ -42,7 +39,7 @@ export const extendedBeatSchema = mulmoBeatSchema.extend({
 export type ExtendedBeat = z.infer<typeof extendedBeatSchema>;
 
 /**
- * Output Profile - 出力プロファイル定義
+ * Output Profile - profile display information
  */
 export const outputProfileSchema = z.object({
   name: z.string(),
@@ -52,7 +49,7 @@ export const outputProfileSchema = z.object({
 export type OutputProfile = z.infer<typeof outputProfileSchema>;
 
 /**
- * Extended Script - variants/meta/outputProfiles を持つ拡張スクリプト
+ * Extended Script - script with variants, meta, and outputProfiles
  */
 export const extendedScriptSchema = mulmoScriptSchema.extend({
   beats: z.array(extendedBeatSchema),
@@ -62,7 +59,7 @@ export const extendedScriptSchema = mulmoScriptSchema.extend({
 export type ExtendedScript = z.infer<typeof extendedScriptSchema>;
 
 /**
- * Process Options - 処理オプション
+ * Process Options - options for processScript
  */
 export interface ProcessOptions {
   profile?: string;
@@ -71,7 +68,7 @@ export interface ProcessOptions {
 }
 
 /**
- * Profile Info - プロファイル情報
+ * Profile Info - profile metadata with beat counts
  */
 export interface ProfileInfo {
   name: string;

--- a/packages/mulmocast-preprocessor/src/types/index.ts
+++ b/packages/mulmocast-preprocessor/src/types/index.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { mulmoBeatSchema, mulmoScriptSchema, type MulmoBeat } from "mulmocast";
+
+/**
+ * MulmoBeat の image フィールドの型を取得
+ */
+export type MulmoImage = MulmoBeat["image"];
+
+/**
+ * Beat Variant - プロファイル別の差し替え定義
+ */
+export const beatVariantSchema = z.object({
+  text: z.string().optional(),
+  skip: z.boolean().optional(),
+  image: z.any().optional(), // MulmoImage type at runtime
+  imagePrompt: z.string().optional(),
+});
+
+export type BeatVariant = z.infer<typeof beatVariantSchema>;
+
+/**
+ * Beat Meta - beatのメタデータ
+ */
+export const beatMetaSchema = z.object({
+  tags: z.array(z.string()).optional(),
+  section: z.string().optional(),
+  context: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  expectedQuestions: z.array(z.string()).optional(),
+});
+
+export type BeatMeta = z.infer<typeof beatMetaSchema>;
+
+/**
+ * Extended Beat - variants と meta を持つ拡張beat
+ */
+export const extendedBeatSchema = mulmoBeatSchema.extend({
+  variants: z.record(z.string(), beatVariantSchema).optional(),
+  meta: beatMetaSchema.optional(),
+});
+
+export type ExtendedBeat = z.infer<typeof extendedBeatSchema>;
+
+/**
+ * Output Profile - 出力プロファイル定義
+ */
+export const outputProfileSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+export type OutputProfile = z.infer<typeof outputProfileSchema>;
+
+/**
+ * Extended Script - variants/meta/outputProfiles を持つ拡張スクリプト
+ */
+export const extendedScriptSchema = mulmoScriptSchema.extend({
+  beats: z.array(extendedBeatSchema),
+  outputProfiles: z.record(z.string(), outputProfileSchema).optional(),
+});
+
+export type ExtendedScript = z.infer<typeof extendedScriptSchema>;
+
+/**
+ * Process Options - 処理オプション
+ */
+export interface ProcessOptions {
+  profile?: string;
+  section?: string;
+  tags?: string[];
+}
+
+/**
+ * Profile Info - プロファイル情報
+ */
+export interface ProfileInfo {
+  name: string;
+  displayName?: string;
+  description?: string;
+  beatCount: number;
+  skippedCount: number;
+}

--- a/packages/mulmocast-preprocessor/test/test_variant.ts
+++ b/packages/mulmocast-preprocessor/test/test_variant.ts
@@ -1,0 +1,177 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { applyProfile, listProfiles, processScript, filterBySection, filterByTags } from "../src/index.js";
+import type { ExtendedScript } from "../src/index.js";
+
+const createTestScript = (): ExtendedScript => ({
+  $mulmocast: { version: "1.1" },
+  title: "Test Script",
+  lang: "ja",
+  speechParams: {
+    speakers: {
+      Host: {
+        voiceId: "shimmer",
+        displayName: { ja: "ホスト" },
+      },
+    },
+  },
+  outputProfiles: {
+    summary: {
+      name: "要約版",
+      description: "短縮版",
+    },
+    teaser: {
+      name: "ティーザー",
+      description: "SNS用",
+    },
+  },
+  beats: [
+    {
+      id: "intro",
+      speaker: "Host",
+      text: "今日はGraphAIについて詳しくお話しします",
+      variants: {
+        summary: { text: "GraphAIの概要を説明します" },
+        teaser: { text: "GraphAI紹介！" },
+      },
+      meta: {
+        tags: ["intro"],
+        section: "opening",
+      },
+    },
+    {
+      id: "detail",
+      speaker: "Host",
+      text: "詳細な説明です...",
+      variants: {
+        summary: { skip: true },
+        teaser: { skip: true },
+      },
+      meta: {
+        tags: ["detail", "technical"],
+        section: "chapter1",
+      },
+    },
+    {
+      id: "conclusion",
+      speaker: "Host",
+      text: "以上がGraphAIでした",
+      variants: {
+        summary: { text: "GraphAIをお試しください" },
+        teaser: { text: "今すぐ試そう！" },
+      },
+      meta: {
+        tags: ["conclusion"],
+        section: "closing",
+      },
+    },
+  ],
+});
+
+describe("applyProfile", () => {
+  it("should apply summary profile", () => {
+    const script = createTestScript();
+    const result = applyProfile(script, "summary");
+
+    assert.strictEqual(result.beats.length, 2);
+    assert.strictEqual(result.beats[0].text, "GraphAIの概要を説明します");
+    assert.strictEqual(result.beats[1].text, "GraphAIをお試しください");
+  });
+
+  it("should apply teaser profile", () => {
+    const script = createTestScript();
+    const result = applyProfile(script, "teaser");
+
+    assert.strictEqual(result.beats.length, 2);
+    assert.strictEqual(result.beats[0].text, "GraphAI紹介！");
+    assert.strictEqual(result.beats[1].text, "今すぐ試そう！");
+  });
+
+  it("should keep original text for unknown profile", () => {
+    const script = createTestScript();
+    const result = applyProfile(script, "unknown");
+
+    assert.strictEqual(result.beats.length, 3);
+    assert.strictEqual(result.beats[0].text, "今日はGraphAIについて詳しくお話しします");
+  });
+
+  it("should remove variants and meta from output", () => {
+    const script = createTestScript();
+    const result = applyProfile(script, "summary");
+
+    assert.strictEqual((result.beats[0] as Record<string, unknown>).variants, undefined);
+    assert.strictEqual((result.beats[0] as Record<string, unknown>).meta, undefined);
+  });
+});
+
+describe("listProfiles", () => {
+  it("should list all profiles", () => {
+    const script = createTestScript();
+    const profiles = listProfiles(script);
+
+    assert.strictEqual(profiles.length, 3);
+
+    const defaultProfile = profiles.find((p) => p.name === "default");
+    assert.ok(defaultProfile);
+    assert.strictEqual(defaultProfile.beatCount, 3);
+    assert.strictEqual(defaultProfile.skippedCount, 0);
+
+    const summaryProfile = profiles.find((p) => p.name === "summary");
+    assert.ok(summaryProfile);
+    assert.strictEqual(summaryProfile.displayName, "要約版");
+    assert.strictEqual(summaryProfile.beatCount, 2);
+    assert.strictEqual(summaryProfile.skippedCount, 1);
+  });
+});
+
+describe("processScript", () => {
+  it("should process with profile option", () => {
+    const script = createTestScript();
+    const result = processScript(script, { profile: "summary" });
+
+    assert.strictEqual(result.beats.length, 2);
+  });
+
+  it("should return all beats with default profile", () => {
+    const script = createTestScript();
+    const result = processScript(script, { profile: "default" });
+
+    assert.strictEqual(result.beats.length, 3);
+  });
+
+  it("should return all beats without options", () => {
+    const script = createTestScript();
+    const result = processScript(script, {});
+
+    assert.strictEqual(result.beats.length, 3);
+  });
+});
+
+describe("filterBySection", () => {
+  it("should filter by section", () => {
+    const script = createTestScript();
+    const result = filterBySection(script, "chapter1");
+
+    assert.strictEqual(result.beats.length, 1);
+    assert.strictEqual(result.beats[0].id, "detail");
+  });
+});
+
+describe("filterByTags", () => {
+  it("should filter by tags", () => {
+    const script = createTestScript();
+    const result = filterByTags(script, ["intro", "conclusion"]);
+
+    assert.strictEqual(result.beats.length, 2);
+    assert.strictEqual(result.beats[0].id, "intro");
+    assert.strictEqual(result.beats[1].id, "conclusion");
+  });
+
+  it("should filter by single tag", () => {
+    const script = createTestScript();
+    const result = filterByTags(script, ["technical"]);
+
+    assert.strictEqual(result.beats.length, 1);
+    assert.strictEqual(result.beats[0].id, "detail");
+  });
+});


### PR DESCRIPTION
## Summary

MulmoScript Preprocessor のコアAPI実装。1つのスクリプトから複数バリエーション（フル版、要約版、ティーザー版など）を生成可能に。

## 実装内容

### 新規API

| 関数 | 説明 |
|------|------|
| `processScript(script, options)` | メイン処理（profile + filter一括） |
| `applyProfile(script, profileName)` | プロファイル適用（text/image差し替え、skip） |
| `filterBySection(script, section)` | セクションフィルタ |
| `filterByTags(script, tags)` | タグフィルタ |
| `listProfiles(script)` | プロファイル一覧取得 |

### 新規型定義

- `BeatVariant` - プロファイル別の差し替え定義
- `BeatMeta` - beatのメタデータ（tags, section等）
- `ExtendedBeat` / `ExtendedScript` - 拡張スキーマ
- `ProcessOptions` / `ProfileInfo` - API用型

### 使用例

```typescript
import { applyProfile, listProfiles } from "mulmocast-preprocessor";

// プロファイル一覧
const profiles = listProfiles(script);
// -> [{ name: "default", beatCount: 7 }, { name: "summary", beatCount: 5, skippedCount: 2 }]

// 要約版を生成
const summary = applyProfile(script, "summary");
// -> variants.summary.text で差し替え
// -> variants.summary.skip === true で除外
```

## テスト

```
✔ applyProfile (4 tests)
✔ listProfiles (1 test)
✔ processScript (3 tests)
✔ filterBySection (1 test)
✔ filterByTags (2 tests)
ℹ pass 11, fail 0
```

## 関連

- #10 実装計画
- #2 preprocessor issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)