### PR TITLE
feat(preprocessor): add CLI with profiles and process commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ensure consistent line endings
+* text=auto eol=lf
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [22, 24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test
+
+      - name: Test CLI (mulmocast-preprocessor)
+        run: |
+          cd packages/mulmocast-preprocessor
+          node lib/cli/index.js --help
+          node lib/cli/index.js profiles test/fixtures/sample.json
+          node lib/cli/index.js test/fixtures/sample.json --profile summary

--- a/packages/mulmocast-preprocessor/README.md
+++ b/packages/mulmocast-preprocessor/README.md
@@ -14,8 +14,31 @@ npm install mulmocast-preprocessor
 - **Section filtering**: Extract beats by section
 - **Tag filtering**: Extract beats by tags
 - **Profile listing**: List available profiles with beat counts
+- **CLI tool**: Command-line interface for processing scripts
 
-## Usage
+## CLI Usage
+
+```bash
+# Process script with profile
+mulmocast-preprocessor script.json --profile summary -o summary.json
+
+# Output to stdout (for piping)
+mulmocast-preprocessor script.json --profile teaser
+
+# List available profiles
+mulmocast-preprocessor profiles script.json
+```
+
+### CLI Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--profile <name>` | `-p` | Profile name to apply (default: "default") |
+| `--output <path>` | `-o` | Output file path (default: stdout) |
+| `--help` | `-h` | Show help |
+| `--version` | `-v` | Show version |
+
+## Programmatic Usage
 
 ### Basic Example
 

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": {
+    "mulmocast-preprocessor": "./lib/cli/index.js"
+  },
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
@@ -31,7 +34,12 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
+    "graphai": "^2.0.16",
     "mulmocast": "^2.1.35",
+    "yargs": "^18.0.0",
     "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/yargs": "^17.0.35"
   }
 }

--- a/packages/mulmocast-preprocessor/src/cli/commands/process.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/process.ts
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from "fs";
+import { GraphAILogger } from "graphai";
+import { processScript } from "../../core/process.js";
+import type { ExtendedScript } from "../../types/index.js";
+
+interface ProcessOptions {
+  profile?: string;
+  output?: string;
+}
+
+/**
+ * Process script with profile and output result
+ */
+export const processCommand = (scriptPath: string, options: ProcessOptions): void => {
+  try {
+    const content = readFileSync(scriptPath, "utf-8");
+    const script: ExtendedScript = JSON.parse(content);
+
+    const result = processScript(script, {
+      profile: options.profile,
+    });
+
+    const output = JSON.stringify(result, null, 2);
+
+    if (options.output) {
+      writeFileSync(options.output, output);
+      GraphAILogger.info(`Output written to ${options.output}`);
+    } else {
+      process.stdout.write(output + "\n");
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      GraphAILogger.error(`Error: ${error.message}`);
+    } else {
+      GraphAILogger.error("Unknown error occurred");
+    }
+    process.exit(1);
+  }
+};

--- a/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "fs";
+import { GraphAILogger } from "graphai";
+import { listProfiles } from "../../core/profiles.js";
+import type { ExtendedScript } from "../../types/index.js";
+
+/**
+ * List available profiles in script
+ */
+export const profilesCommand = (scriptPath: string): void => {
+  try {
+    const content = readFileSync(scriptPath, "utf-8");
+    const script: ExtendedScript = JSON.parse(content);
+
+    const profiles = listProfiles(script);
+
+    GraphAILogger.log("\nAvailable profiles:");
+    profiles.forEach((profile) => {
+      const displayName = profile.displayName ? ` (${profile.displayName})` : "";
+      const skipped = profile.skippedCount > 0 ? `, ${profile.skippedCount} skipped` : "";
+      GraphAILogger.log(`  ${profile.name}${displayName}: ${profile.beatCount} beats${skipped}`);
+      if (profile.description) {
+        GraphAILogger.log(`    ${profile.description}`);
+      }
+    });
+    GraphAILogger.log("");
+  } catch (error) {
+    if (error instanceof Error) {
+      GraphAILogger.error(`Error: ${error.message}`);
+    } else {
+      GraphAILogger.error("Unknown error occurred");
+    }
+    process.exit(1);
+  }
+};

--- a/packages/mulmocast-preprocessor/src/cli/index.ts
+++ b/packages/mulmocast-preprocessor/src/cli/index.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { processCommand } from "./commands/process.js";
+import { profilesCommand } from "./commands/profiles.js";
+
+yargs(hideBin(process.argv))
+  .command(
+    "$0 <script>",
+    "Process MulmoScript with profile",
+    (builder) =>
+      builder
+        .positional("script", {
+          describe: "Path to MulmoScript JSON file",
+          type: "string",
+          demandOption: true,
+        })
+        .option("profile", {
+          alias: "p",
+          describe: "Profile name to apply",
+          type: "string",
+          default: "default",
+        })
+        .option("output", {
+          alias: "o",
+          describe: "Output file path (default: stdout)",
+          type: "string",
+        }),
+    (argv) => {
+      processCommand(argv.script, {
+        profile: argv.profile,
+        output: argv.output,
+      });
+    },
+  )
+  .command(
+    "profiles <script>",
+    "List available profiles in script",
+    (builder) =>
+      builder.positional("script", {
+        describe: "Path to MulmoScript JSON file",
+        type: "string",
+        demandOption: true,
+      }),
+    (argv) => {
+      profilesCommand(argv.script);
+    },
+  )
+  .example("$0 script.json --profile summary -o summary.json", "Apply summary profile and save to file")
+  .example("$0 script.json -p teaser", "Apply teaser profile and output to stdout")
+  .example("$0 profiles script.json", "List all available profiles")
+  .help()
+  .alias("h", "help")
+  .version()
+  .alias("v", "version")
+  .strict()
+  .parse();

--- a/packages/mulmocast-preprocessor/test/fixtures/sample.json
+++ b/packages/mulmocast-preprocessor/test/fixtures/sample.json
@@ -1,0 +1,71 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "title": "Sample Script",
+  "lang": "en",
+  "outputProfiles": {
+    "summary": {
+      "name": "Summary Version",
+      "description": "Short summary of the content"
+    },
+    "teaser": {
+      "name": "Teaser",
+      "description": "30 second teaser"
+    }
+  },
+  "speechParams": {
+    "speakers": {
+      "Host": {
+        "voiceId": "shimmer"
+      }
+    }
+  },
+  "beats": [
+    {
+      "speaker": "Host",
+      "text": "Welcome to this detailed presentation about our topic.",
+      "variants": {
+        "summary": { "text": "Welcome to the summary." },
+        "teaser": { "text": "Check this out!" }
+      },
+      "meta": {
+        "tags": ["intro"],
+        "section": "opening"
+      }
+    },
+    {
+      "speaker": "Host",
+      "text": "Let me explain the background in detail. This is a long explanation about history.",
+      "variants": {
+        "summary": { "text": "Brief background info." },
+        "teaser": { "skip": true }
+      },
+      "meta": {
+        "tags": ["background"],
+        "section": "chapter1"
+      }
+    },
+    {
+      "speaker": "Host",
+      "text": "Now for the main content and demonstration.",
+      "variants": {
+        "teaser": { "skip": true }
+      },
+      "meta": {
+        "tags": ["main", "demo"],
+        "section": "chapter1"
+      }
+    },
+    {
+      "speaker": "Host",
+      "text": "Thank you for watching. Please try it yourself!",
+      "variants": {
+        "summary": { "text": "Thanks! Try it now." },
+        "teaser": { "text": "Try it now!" }
+      },
+      "meta": {
+        "tags": ["conclusion"],
+        "section": "closing"
+      }
+    }
+  ]
+}

--- a/packages/mulmocast-preprocessor/test/test_cli.ts
+++ b/packages/mulmocast-preprocessor/test/test_cli.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { execSync } from "child_process";
+import { readFileSync, unlinkSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = join(__dirname, "../lib/cli/index.js");
+const FIXTURE_PATH = join(__dirname, "fixtures/sample.json");
+
+const runCli = (args: string): string => {
+  return execSync(`node ${CLI_PATH} ${args}`, { encoding: "utf-8" });
+};
+
+describe("CLI", () => {
+  describe("help", () => {
+    it("should show help with --help", () => {
+      const output = runCli("--help");
+      assert.ok(output.includes("Process MulmoScript with profile"));
+      assert.ok(output.includes("--profile"));
+      assert.ok(output.includes("--output"));
+    });
+  });
+
+  describe("version", () => {
+    it("should show version with --version", () => {
+      const output = runCli("--version");
+      assert.match(output.trim(), /^\d+\.\d+\.\d+$/);
+    });
+  });
+
+  describe("profiles command", () => {
+    it("should list available profiles", () => {
+      const output = runCli(`profiles ${FIXTURE_PATH}`);
+      assert.ok(output.includes("Available profiles:"));
+      assert.ok(output.includes("default"));
+      assert.ok(output.includes("summary"));
+      assert.ok(output.includes("teaser"));
+      assert.ok(output.includes("4 beats"));
+      assert.ok(output.includes("2 skipped"));
+    });
+  });
+
+  describe("process command", () => {
+    it("should process with default profile", () => {
+      const output = runCli(FIXTURE_PATH);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 4);
+      assert.equal(result.beats[0].text, "Welcome to this detailed presentation about our topic.");
+    });
+
+    it("should process with summary profile", () => {
+      const output = runCli(`${FIXTURE_PATH} --profile summary`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 4);
+      assert.equal(result.beats[0].text, "Welcome to the summary.");
+      assert.equal(result.beats[1].text, "Brief background info.");
+    });
+
+    it("should process with teaser profile (skip beats)", () => {
+      const output = runCli(`${FIXTURE_PATH} --profile teaser`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 2);
+      assert.equal(result.beats[0].text, "Check this out!");
+      assert.equal(result.beats[1].text, "Try it now!");
+    });
+
+    it("should output to file with -o option", () => {
+      const outputPath = join(__dirname, "fixtures/output_test.json");
+
+      try {
+        runCli(`${FIXTURE_PATH} --profile summary -o ${outputPath}`);
+        assert.ok(existsSync(outputPath));
+
+        const content = readFileSync(outputPath, "utf-8");
+        const result = JSON.parse(content);
+        assert.equal(result.beats.length, 4);
+        assert.equal(result.beats[0].text, "Welcome to the summary.");
+      } finally {
+        if (existsSync(outputPath)) {
+          unlinkSync(outputPath);
+        }
+      }
+    });
+
+    it("should strip variants and meta from output", () => {
+      const output = runCli(`${FIXTURE_PATH} --profile summary`);
+      const result = JSON.parse(output);
+
+      result.beats.forEach((beat: Record<string, unknown>) => {
+        assert.ok(!("variants" in beat), "variants should be stripped");
+        assert.ok(!("meta" in beat), "meta should be stripped");
+      });
+
+      assert.ok(!("outputProfiles" in result), "outputProfiles should be stripped");
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,6 +728,18 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/yargs-parser@*":
+  version "21.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
+  integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.35":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@types/yauzl@^2.9.1":
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"


### PR DESCRIPTION
## Summary

MulmoScript Preprocessor のCLI実装。Phase 3 & 4 完了。

## 実装内容

### CLI コマンド

```bash
# プロファイル適用
mulmocast-preprocessor script.json --profile summary -o summary.json

# プロファイル一覧
mulmocast-preprocessor profiles script.json
```

### オプション

| Option | Alias | Description |
|--------|-------|-------------|
| `--profile <name>` | `-p` | Profile name to apply |
| `--output <path>` | `-o` | Output file path |
| `--help` | `-h` | Show help |
| `--version` | `-v` | Show version |

### 新規ファイル

- `src/cli/index.ts` - CLI エントリーポイント (yargs)
- `src/cli/commands/process.ts` - メイン処理コマンド
- `src/cli/commands/profiles.ts` - プロファイル一覧コマンド
- `test/test_cli.ts` - CLIユニットテスト
- `.github/workflows/ci.yml` - GitHub Actions CI

## テスト

```
✔ CLI (8 tests)
  ✔ help
  ✔ version
  ✔ profiles command
  ✔ process command (5 tests)
✔ Core API (11 tests)
ℹ pass 19, fail 0
```

## 関連

- #2 preprocessor issue
- Phase 3 & 4 of plan_preprocessor.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)