### PR TITLE
feat(preprocessor): add --section and --tags filter options

### DIFF
--- a/packages/mulmocast-preprocessor/README.md
+++ b/packages/mulmocast-preprocessor/README.md
@@ -25,6 +25,15 @@ mulmocast-preprocessor script.json --profile summary -o summary.json
 # Output to stdout (for piping)
 mulmocast-preprocessor script.json --profile teaser
 
+# Filter by section
+mulmocast-preprocessor script.json --section chapter1
+
+# Filter by tags
+mulmocast-preprocessor script.json --tags concept,demo
+
+# Combine profile and filters
+mulmocast-preprocessor script.json --profile summary --section chapter1
+
 # List available profiles
 mulmocast-preprocessor profiles script.json
 ```
@@ -35,6 +44,8 @@ mulmocast-preprocessor profiles script.json
 |--------|-------|-------------|
 | `--profile <name>` | `-p` | Profile name to apply (default: "default") |
 | `--output <path>` | `-o` | Output file path (default: stdout) |
+| `--section <name>` | `-s` | Filter by section name |
+| `--tags <tags>` | `-t` | Filter by tags (comma-separated) |
 | `--help` | `-h` | Show help |
 | `--version` | `-v` | Show version |
 

--- a/packages/mulmocast-preprocessor/src/cli/commands/process.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/process.ts
@@ -6,6 +6,8 @@ import type { ExtendedScript } from "../../types/index.js";
 interface ProcessOptions {
   profile?: string;
   output?: string;
+  section?: string;
+  tags?: string[];
 }
 
 /**
@@ -18,6 +20,8 @@ export const processCommand = (scriptPath: string, options: ProcessOptions): voi
 
     const result = processScript(script, {
       profile: options.profile,
+      section: options.section,
+      tags: options.tags,
     });
 
     const output = JSON.stringify(result, null, 2);

--- a/packages/mulmocast-preprocessor/src/cli/index.ts
+++ b/packages/mulmocast-preprocessor/src/cli/index.ts
@@ -26,11 +26,24 @@ yargs(hideBin(process.argv))
           alias: "o",
           describe: "Output file path (default: stdout)",
           type: "string",
+        })
+        .option("section", {
+          alias: "s",
+          describe: "Filter by section name",
+          type: "string",
+        })
+        .option("tags", {
+          alias: "t",
+          describe: "Filter by tags (comma-separated)",
+          type: "string",
         }),
     (argv) => {
+      const tags = argv.tags ? argv.tags.split(",").map((t) => t.trim()) : undefined;
       processCommand(argv.script, {
         profile: argv.profile,
         output: argv.output,
+        section: argv.section,
+        tags,
       });
     },
   )
@@ -49,6 +62,9 @@ yargs(hideBin(process.argv))
   )
   .example("$0 script.json --profile summary -o summary.json", "Apply summary profile and save to file")
   .example("$0 script.json -p teaser", "Apply teaser profile and output to stdout")
+  .example("$0 script.json --section chapter1", "Filter by section")
+  .example("$0 script.json --tags concept,demo", "Filter by tags")
+  .example("$0 script.json -p summary -s chapter1", "Combine profile and section filter")
   .example("$0 profiles script.json", "List all available profiles")
   .help()
   .alias("h", "help")

--- a/packages/mulmocast-preprocessor/src/core/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/filter.ts
@@ -6,7 +6,7 @@ const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
   return baseBeat;
 };
 
-const filterBeats = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): MulmoScript => {
+const filterBeatsToMulmoScript = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): MulmoScript => {
   const { outputProfiles: __outputProfiles, ...baseScript } = script;
   return {
     ...baseScript,
@@ -14,20 +14,26 @@ const filterBeats = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => 
   } as MulmoScript;
 };
 
-/**
- * Filter beats by section
- */
-export const filterBySection = (script: ExtendedScript, section: string): MulmoScript => filterBeats(script, (beat) => beat.meta?.section === section);
+const filterBeatsPreservingMeta = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): ExtendedScript => ({
+  ...script,
+  beats: script.beats.filter(predicate),
+});
 
 /**
- * Filter beats by tags (extract beats that have any of the specified tags)
+ * Filter beats by section (preserves meta for chaining)
  */
-export const filterByTags = (script: ExtendedScript, tags: string[]): MulmoScript => {
+export const filterBySection = (script: ExtendedScript, section: string): ExtendedScript =>
+  filterBeatsPreservingMeta(script, (beat) => beat.meta?.section === section);
+
+/**
+ * Filter beats by tags (preserves meta for chaining)
+ */
+export const filterByTags = (script: ExtendedScript, tags: string[]): ExtendedScript => {
   const tagSet = new Set(tags);
-  return filterBeats(script, (beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag)));
+  return filterBeatsPreservingMeta(script, (beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag)));
 };
 
 /**
  * Strip variants and meta fields, converting to standard MulmoScript
  */
-export const stripExtendedFields = (script: ExtendedScript): MulmoScript => filterBeats(script, () => true);
+export const stripExtendedFields = (script: ExtendedScript): MulmoScript => filterBeatsToMulmoScript(script, () => true);

--- a/packages/mulmocast-preprocessor/src/core/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/process.ts
@@ -3,21 +3,16 @@ import type { ExtendedScript, ProcessOptions } from "../types/index.js";
 import { applyProfile } from "./variant.js";
 import { filterBySection, filterByTags, stripExtendedFields } from "./filter.js";
 
-const toExtendedScript = (script: MulmoScript): ExtendedScript => ({
-  ...script,
-  beats: script.beats.map((beat) => ({ ...beat })),
-});
-
 /**
  * Main processing function
- * Applies profile and filters in a single call
+ * Applies filters first (while meta exists), then profile
  */
 export const processScript = (script: ExtendedScript, options: ProcessOptions = {}): MulmoScript => {
-  const afterProfile = options.profile && options.profile !== "default" ? applyProfile(script, options.profile) : stripExtendedFields(script);
+  const afterSection = options.section ? filterBySection(script, options.section) : script;
 
-  const afterSection = options.section ? filterBySection(toExtendedScript(afterProfile), options.section) : afterProfile;
+  const afterTags = options.tags && options.tags.length > 0 ? filterByTags(afterSection, options.tags) : afterSection;
 
-  const afterTags = options.tags && options.tags.length > 0 ? filterByTags(toExtendedScript(afterSection), options.tags) : afterSection;
+  const afterProfile = options.profile && options.profile !== "default" ? applyProfile(afterTags, options.profile) : stripExtendedFields(afterTags);
 
-  return afterTags;
+  return afterProfile;
 };

--- a/packages/mulmocast-preprocessor/test/test_cli.ts
+++ b/packages/mulmocast-preprocessor/test/test_cli.ts
@@ -95,5 +95,31 @@ describe("CLI", () => {
 
       assert.ok(!("outputProfiles" in result), "outputProfiles should be stripped");
     });
+
+    it("should filter by section", () => {
+      const output = runCli(`${FIXTURE_PATH} --section chapter1`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 2);
+    });
+
+    it("should filter by tags", () => {
+      const output = runCli(`${FIXTURE_PATH} --tags intro,conclusion`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 2);
+    });
+
+    it("should combine profile and section filter", () => {
+      const output = runCli(`${FIXTURE_PATH} --profile summary --section chapter1`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 2);
+      assert.equal(result.beats[0].text, "Brief background info.");
+    });
+
+    it("should combine profile and tags filter", () => {
+      const output = runCli(`${FIXTURE_PATH} --profile summary --tags intro`);
+      const result = JSON.parse(output);
+      assert.equal(result.beats.length, 1);
+      assert.equal(result.beats[0].text, "Welcome to the summary.");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Phase 5: フィルタオプションの実装。

## 実装内容

### 新しいCLIオプション

```bash
# セクションでフィルタ
mulmocast-preprocessor script.json --section chapter1

# タグでフィルタ
mulmocast-preprocessor script.json --tags concept,demo

# プロファイルとフィルタの組み合わせ
mulmocast-preprocessor script.json --profile summary --section chapter1
```

| Option | Alias | Description |
|--------|-------|-------------|
| `--section <name>` | `-s` | Filter by section name |
| `--tags <tags>` | `-t` | Filter by tags (comma-separated) |

### 処理順序

フィルタはプロファイル適用の**前**に実行（metaが存在する状態で）:

1. `filterBySection` (meta保持)
2. `filterByTags` (meta保持)  
3. `applyProfile` または `stripExtendedFields` (meta削除)

### 変更点

- `filterBySection`/`filterByTags`: `ExtendedScript`を返すように変更（チェーン可能）
- `processScript`: フィルタ→プロファイルの順序に修正

## テスト

```
✔ CLI (23 tests)
  ✔ should filter by section
  ✔ should filter by tags
  ✔ should combine profile and section filter
  ✔ should combine profile and tags filter
ℹ pass 23, fail 0
```

## 関連

- #2 preprocessor issue
- Phase 5 of plan_preprocessor.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)