### PR TITLE
feat(preprocessor): add summarize command for script content summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@types/node": "^25.2.0",
+    "@types/node": "^25.2.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -34,6 +34,12 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
+    "@graphai/anthropic_agent": "^2.0.12",
+    "@graphai/gemini_agent": "^2.0.5",
+    "@graphai/groq_agent": "^2.0.2",
+    "@graphai/openai_agent": "^2.0.9",
+    "@graphai/vanilla": "^2.0.12",
+    "dotenv": "^17.2.4",
     "graphai": "^2.0.16",
     "mulmocast": "^2.1.35",
     "yargs": "^18.0.0",

--- a/packages/mulmocast-preprocessor/src/cli/commands/summarize.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/summarize.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+import { GraphAILogger } from "graphai";
+import { summarizeScript } from "../../core/summarize/index.js";
+import type { ExtendedScript } from "../../types/index.js";
+import type { LLMProvider, SummarizeFormat } from "../../types/summarize.js";
+
+interface SummarizeCommandOptions {
+  provider?: LLMProvider;
+  model?: string;
+  format?: SummarizeFormat;
+  targetLength?: number;
+  systemPrompt?: string;
+  verbose?: boolean;
+  section?: string;
+  tags?: string[];
+}
+
+/**
+ * Summarize command handler - outputs summary to stdout
+ */
+export const summarizeCommand = async (scriptPath: string, options: SummarizeCommandOptions): Promise<void> => {
+  try {
+    const content = readFileSync(scriptPath, "utf-8");
+    const script: ExtendedScript = JSON.parse(content);
+
+    const result = await summarizeScript(script, {
+      provider: options.provider ?? "openai",
+      model: options.model,
+      format: options.format ?? "text",
+      targetLengthChars: options.targetLength,
+      systemPrompt: options.systemPrompt,
+      verbose: options.verbose ?? false,
+      section: options.section,
+      tags: options.tags,
+    });
+
+    // Output summary to stdout
+    process.stdout.write(result.summary + "\n");
+  } catch (error) {
+    if (error instanceof Error) {
+      GraphAILogger.error(`Error: ${error.message}`);
+    } else {
+      GraphAILogger.error("Unknown error occurred");
+    }
+    process.exit(1);
+  }
+};

--- a/packages/mulmocast-preprocessor/src/core/summarize/index.ts
+++ b/packages/mulmocast-preprocessor/src/core/summarize/index.ts
@@ -1,0 +1,145 @@
+import dotenv from "dotenv";
+import { GraphAI, GraphAILogger } from "graphai";
+import type { GraphData } from "graphai";
+import * as vanillaAgents from "@graphai/vanilla";
+import { openAIAgent } from "@graphai/openai_agent";
+import { anthropicAgent } from "@graphai/anthropic_agent";
+import { groqAgent } from "@graphai/groq_agent";
+import { geminiAgent } from "@graphai/gemini_agent";
+
+import type { ExtendedScript } from "../../types/index.js";
+import type { SummarizeOptions, SummarizeResult } from "../../types/summarize.js";
+import { summarizeOptionsSchema } from "../../types/summarize.js";
+import { getProviderConfig, getProviderApiKey } from "./provider.js";
+import { buildUserPrompt, getSystemPrompt } from "./prompts.js";
+import { filterBySection, filterByTags } from "../filter.js";
+
+dotenv.config({ quiet: true });
+
+const agents = vanillaAgents.default ?? vanillaAgents;
+
+/**
+ * Create GraphAI graph for summarizing script
+ */
+const createSummarizeGraph = (agentName: string): GraphData => ({
+  version: 0.5,
+  nodes: {
+    systemPrompt: {},
+    userPrompt: {},
+    model: {},
+    temperature: {},
+    maxTokens: {},
+
+    llmCall: {
+      agent: agentName,
+      inputs: {
+        system: ":systemPrompt",
+        prompt: ":userPrompt",
+        model: ":model",
+        temperature: ":temperature",
+        max_tokens: ":maxTokens",
+      },
+    },
+
+    result: {
+      isResult: true,
+      agent: "copyAgent",
+      inputs: {
+        summary: ":llmCall.text",
+      },
+    },
+  },
+});
+
+/**
+ * Filter script based on options (section, tags)
+ */
+const filterScript = (script: ExtendedScript, options: SummarizeOptions): ExtendedScript => {
+  const afterSection = options.section ? filterBySection(script, options.section) : script;
+  const afterTags = options.tags && options.tags.length > 0 ? filterByTags(afterSection, options.tags) : afterSection;
+  return afterTags;
+};
+
+/**
+ * Main summarize function - generates a summary of the entire script
+ */
+export const summarizeScript = async (script: ExtendedScript, options: Partial<SummarizeOptions> = {}): Promise<SummarizeResult> => {
+  // Validate and apply defaults
+  const validatedOptions = summarizeOptionsSchema.parse(options);
+
+  const providerConfig = getProviderConfig(validatedOptions.provider);
+  const apiKey = getProviderApiKey(validatedOptions.provider);
+
+  if (!apiKey) {
+    throw new Error(`API key not found for provider "${validatedOptions.provider}". ` + `Please set the ${providerConfig.keyName} environment variable.`);
+  }
+
+  // Filter script if section/tags specified
+  const filteredScript = filterScript(script, validatedOptions);
+
+  const scriptTitle = script.title || "Untitled";
+
+  if (filteredScript.beats.length === 0) {
+    return {
+      summary: "No content to summarize.",
+      format: validatedOptions.format,
+      scriptTitle,
+      beatCount: 0,
+    };
+  }
+
+  // Build GraphAI config
+  const config: Record<string, { apiKey?: string }> = {
+    openAIAgent: { apiKey: process.env.OPENAI_API_KEY },
+    anthropicAgent: { apiKey: process.env.ANTHROPIC_API_KEY },
+    groqAgent: { apiKey: process.env.GROQ_API_KEY },
+    geminiAgent: { apiKey: process.env.GEMINI_API_KEY },
+  };
+
+  // Create GraphAI instance
+  const graph = new GraphAI(
+    createSummarizeGraph(providerConfig.agentName),
+    {
+      ...agents,
+      openAIAgent,
+      anthropicAgent,
+      groqAgent,
+      geminiAgent,
+    },
+    { config },
+  );
+
+  // Build prompts
+  const systemPrompt = getSystemPrompt(validatedOptions);
+  const userPrompt = buildUserPrompt(filteredScript, validatedOptions);
+
+  if (validatedOptions.verbose) {
+    GraphAILogger.info(`Summarizing script "${script.title}" with ${validatedOptions.provider}...`);
+    GraphAILogger.info(`Beats: ${filteredScript.beats.length}, Format: ${validatedOptions.format}`);
+  }
+
+  // Inject values
+  graph.injectValue("systemPrompt", systemPrompt);
+  graph.injectValue("userPrompt", userPrompt);
+  graph.injectValue("model", validatedOptions.model ?? providerConfig.defaultModel);
+  graph.injectValue("temperature", validatedOptions.temperature ?? 0.7);
+  graph.injectValue("maxTokens", validatedOptions.maxTokens ?? providerConfig.maxTokens ?? 2048);
+
+  // Run graph
+  const graphResult = await graph.run();
+
+  // Extract summary from result node
+  const resultNode = graphResult.result as { summary?: string } | undefined;
+  const summary = resultNode?.summary || "";
+
+  return {
+    summary,
+    format: validatedOptions.format,
+    scriptTitle,
+    beatCount: filteredScript.beats.length,
+  };
+};
+
+// Re-export types
+export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat } from "../../types/summarize.js";
+export { summarizeOptionsSchema, llmProviderSchema, summarizeFormatSchema } from "../../types/summarize.js";

--- a/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
@@ -4,19 +4,22 @@ import type { ExtendedScript } from "../../types/index.js";
 /**
  * Default system prompt for text summary
  */
-export const DEFAULT_SYSTEM_PROMPT_TEXT = `You are summarizing a presentation/podcast script.
-- Read all the content and create a concise summary
-- Capture the main topic, key points, and conclusion
-- Write in a clear, informative style
+export const DEFAULT_SYSTEM_PROMPT_TEXT = `You are creating a summary based on the content provided.
+- Extract and explain the actual information and knowledge from the content
+- Do NOT describe what the presentation/script is about (avoid phrases like "this presentation explains..." or "the script describes...")
+- Write as if you are directly explaining the topic to the reader
+- Be concise and informative
 - Output plain text only`;
 
 /**
  * Default system prompt for markdown summary
  */
-export const DEFAULT_SYSTEM_PROMPT_MARKDOWN = `You are summarizing a presentation/podcast script.
-- Read all the content and create a structured summary
-- Include: title, overview, key points, and conclusion
+export const DEFAULT_SYSTEM_PROMPT_MARKDOWN = `You are creating a summary based on the content provided.
+- Extract and explain the actual information and knowledge from the content
+- Do NOT describe what the presentation/script is about (avoid phrases like "this presentation explains..." or "the script describes...")
+- Write as if you are directly explaining the topic to the reader
 - Use markdown formatting (headers, bullet points, etc.)
+- Include a title, key points, and conclusion
 - Output well-formatted markdown`;
 
 /**
@@ -57,7 +60,7 @@ export const buildUserPrompt = (script: ExtendedScript, options: SummarizeOption
   }
 
   parts.push("");
-  parts.push("Please summarize this script:");
+  parts.push("Based on the above content, explain the topic directly to the reader:");
 
   return parts.join("\n");
 };

--- a/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
@@ -1,0 +1,73 @@
+import type { SummarizeOptions } from "../../types/summarize.js";
+import type { ExtendedScript } from "../../types/index.js";
+
+/**
+ * Default system prompt for text summary
+ */
+export const DEFAULT_SYSTEM_PROMPT_TEXT = `You are summarizing a presentation/podcast script.
+- Read all the content and create a concise summary
+- Capture the main topic, key points, and conclusion
+- Write in a clear, informative style
+- Output plain text only`;
+
+/**
+ * Default system prompt for markdown summary
+ */
+export const DEFAULT_SYSTEM_PROMPT_MARKDOWN = `You are summarizing a presentation/podcast script.
+- Read all the content and create a structured summary
+- Include: title, overview, key points, and conclusion
+- Use markdown formatting (headers, bullet points, etc.)
+- Output well-formatted markdown`;
+
+/**
+ * Build user prompt from entire script
+ */
+export const buildUserPrompt = (script: ExtendedScript, options: SummarizeOptions): string => {
+  const parts: string[] = [];
+
+  // Add script metadata
+  parts.push(`# Script: ${script.title}`);
+  parts.push(`Language: ${script.lang}`);
+  parts.push("");
+
+  // Collect all text from beats
+  const sections = new Map<string, string[]>();
+
+  script.beats.forEach((beat, index) => {
+    const text = beat.text || "";
+    if (!text.trim()) return;
+
+    const section = beat.meta?.section || "main";
+    if (!sections.has(section)) {
+      sections.set(section, []);
+    }
+    sections.get(section)!.push(`[${index}] ${text}`);
+  });
+
+  // Output by section
+  sections.forEach((texts, section) => {
+    parts.push(`## Section: ${section}`);
+    texts.forEach((t) => parts.push(t));
+    parts.push("");
+  });
+
+  // Add target length if specified
+  if (options.targetLengthChars) {
+    parts.push(`Target summary length: approximately ${options.targetLengthChars} characters`);
+  }
+
+  parts.push("");
+  parts.push("Please summarize this script:");
+
+  return parts.join("\n");
+};
+
+/**
+ * Get system prompt based on format
+ */
+export const getSystemPrompt = (options: SummarizeOptions): string => {
+  if (options.systemPrompt) {
+    return options.systemPrompt;
+  }
+  return options.format === "markdown" ? DEFAULT_SYSTEM_PROMPT_MARKDOWN : DEFAULT_SYSTEM_PROMPT_TEXT;
+};

--- a/packages/mulmocast-preprocessor/src/core/summarize/provider.ts
+++ b/packages/mulmocast-preprocessor/src/core/summarize/provider.ts
@@ -1,0 +1,47 @@
+import type { ProviderConfig, LLMProvider } from "../../types/summarize.js";
+
+/**
+ * Provider to LLM agent configuration mapping
+ * Following mulmocast-cli provider2agent pattern
+ */
+export const provider2SummarizeAgent: Record<LLMProvider, ProviderConfig> = {
+  openai: {
+    agentName: "openAIAgent",
+    defaultModel: "gpt-4o-mini",
+    keyName: "OPENAI_API_KEY",
+    maxTokens: 8192,
+  },
+  anthropic: {
+    agentName: "anthropicAgent",
+    defaultModel: "claude-sonnet-4-20250514",
+    keyName: "ANTHROPIC_API_KEY",
+    maxTokens: 8192,
+  },
+  groq: {
+    agentName: "groqAgent",
+    defaultModel: "llama-3.1-8b-instant",
+    keyName: "GROQ_API_KEY",
+    maxTokens: 4096,
+  },
+  gemini: {
+    agentName: "geminiAgent",
+    defaultModel: "gemini-2.0-flash",
+    keyName: "GEMINI_API_KEY",
+    maxTokens: 8192,
+  },
+};
+
+/**
+ * Get provider config by provider name
+ */
+export const getProviderConfig = (provider: LLMProvider): ProviderConfig => {
+  return provider2SummarizeAgent[provider];
+};
+
+/**
+ * Get API key from environment for provider
+ */
+export const getProviderApiKey = (provider: LLMProvider): string | undefined => {
+  const config = provider2SummarizeAgent[provider];
+  return process.env[config.keyName];
+};

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -4,8 +4,13 @@ export { applyProfile } from "./core/variant.js";
 export { filterBySection, filterByTags, stripExtendedFields } from "./core/filter.js";
 export { listProfiles } from "./core/profiles.js";
 
+// Summarize API
+export { summarizeScript } from "./core/summarize/index.js";
+
 // Types
 export type { BeatVariant, BeatMeta, ExtendedBeat, ExtendedScript, OutputProfile, ProcessOptions, ProfileInfo } from "./types/index.js";
+export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat, ProviderConfig } from "./types/summarize.js";
 
 // Schemas (for validation)
 export { beatVariantSchema, beatMetaSchema, extendedBeatSchema, extendedScriptSchema, outputProfileSchema } from "./types/index.js";
+export { summarizeOptionsSchema, llmProviderSchema, summarizeFormatSchema } from "./types/summarize.js";

--- a/packages/mulmocast-preprocessor/src/types/summarize.ts
+++ b/packages/mulmocast-preprocessor/src/types/summarize.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+/**
+ * LLM Provider - supported providers for summarization
+ */
+export const llmProviderSchema = z.enum(["openai", "anthropic", "groq", "gemini"]);
+export type LLMProvider = z.infer<typeof llmProviderSchema>;
+
+/**
+ * Output format for summary
+ */
+export const summarizeFormatSchema = z.enum(["text", "markdown"]);
+export type SummarizeFormat = z.infer<typeof summarizeFormatSchema>;
+
+/**
+ * Summarize Options - configuration for summarization
+ */
+export const summarizeOptionsSchema = z.object({
+  // LLM settings
+  provider: llmProviderSchema.default("openai"),
+  model: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  maxTokens: z.number().positive().optional(),
+
+  // Output format
+  format: summarizeFormatSchema.default("text"),
+
+  // Target length (optional)
+  targetLengthChars: z.number().positive().optional(),
+
+  // Custom prompt
+  systemPrompt: z.string().optional(),
+
+  // Processing options
+  verbose: z.boolean().default(false),
+
+  // Beat filtering
+  section: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+export type SummarizeOptions = z.infer<typeof summarizeOptionsSchema>;
+
+/**
+ * Summarize Result - the generated summary
+ */
+export interface SummarizeResult {
+  summary: string;
+  format: SummarizeFormat;
+  scriptTitle: string;
+  beatCount: number;
+}
+
+/**
+ * Provider Config - configuration for LLM provider
+ */
+export interface ProviderConfig {
+  agentName: string;
+  defaultModel: string;
+  keyName: string;
+  maxTokens?: number;
+}

--- a/packages/mulmocast-preprocessor/test/test_summarize.ts
+++ b/packages/mulmocast-preprocessor/test/test_summarize.ts
@@ -1,0 +1,154 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { buildUserPrompt, getSystemPrompt, DEFAULT_SYSTEM_PROMPT_TEXT, DEFAULT_SYSTEM_PROMPT_MARKDOWN } from "../src/core/summarize/prompts.js";
+import { getProviderConfig, provider2SummarizeAgent } from "../src/core/summarize/provider.js";
+import type { ExtendedScript } from "../src/index.js";
+import type { SummarizeOptions } from "../src/types/summarize.js";
+
+const createTestOptions = (overrides?: Partial<SummarizeOptions>): SummarizeOptions => ({
+  provider: "openai",
+  format: "text",
+  verbose: false,
+  ...overrides,
+});
+
+const createTestScript = (): ExtendedScript => ({
+  $mulmocast: { version: "1.1" },
+  title: "Test Script",
+  lang: "en",
+  speechParams: {
+    speakers: {
+      Host: {
+        voiceId: "shimmer",
+        displayName: { en: "Host" },
+      },
+    },
+  },
+  beats: [
+    {
+      id: "beat1",
+      speaker: "Host",
+      text: "This is the first beat with a long explanation that could be shortened.",
+      meta: {
+        tags: ["intro"],
+        section: "opening",
+      },
+    },
+    {
+      id: "beat2",
+      speaker: "Host",
+      text: "This is a detailed technical explanation that goes into depth.",
+      meta: {
+        tags: ["detail", "technical"],
+        section: "chapter1",
+      },
+    },
+    {
+      id: "beat3",
+      speaker: "Host",
+      text: "Final conclusion wrapping up everything.",
+      meta: {
+        tags: ["conclusion"],
+        section: "closing",
+      },
+    },
+  ],
+});
+
+describe("buildUserPrompt", () => {
+  it("should include script title and language", () => {
+    const script = createTestScript();
+    const options = createTestOptions();
+    const prompt = buildUserPrompt(script, options);
+
+    assert.ok(prompt.includes("# Script: Test Script"));
+    assert.ok(prompt.includes("Language: en"));
+  });
+
+  it("should include all beat texts grouped by section", () => {
+    const script = createTestScript();
+    const options = createTestOptions();
+    const prompt = buildUserPrompt(script, options);
+
+    assert.ok(prompt.includes("## Section: opening"));
+    assert.ok(prompt.includes("## Section: chapter1"));
+    assert.ok(prompt.includes("## Section: closing"));
+    assert.ok(prompt.includes("first beat"));
+    assert.ok(prompt.includes("technical explanation"));
+    assert.ok(prompt.includes("conclusion"));
+  });
+
+  it("should include target length when specified", () => {
+    const script = createTestScript();
+    const options = createTestOptions({ targetLengthChars: 200 });
+    const prompt = buildUserPrompt(script, options);
+
+    assert.ok(prompt.includes("Target summary length: approximately 200 characters"));
+  });
+});
+
+describe("getSystemPrompt", () => {
+  it("should return text prompt for text format", () => {
+    const options = createTestOptions({ format: "text" });
+    const prompt = getSystemPrompt(options);
+
+    assert.strictEqual(prompt, DEFAULT_SYSTEM_PROMPT_TEXT);
+    assert.ok(prompt.includes("plain text"));
+  });
+
+  it("should return markdown prompt for markdown format", () => {
+    const options = createTestOptions({ format: "markdown" });
+    const prompt = getSystemPrompt(options);
+
+    assert.strictEqual(prompt, DEFAULT_SYSTEM_PROMPT_MARKDOWN);
+    assert.ok(prompt.includes("markdown"));
+  });
+
+  it("should use custom system prompt when provided", () => {
+    const customPrompt = "Custom summarization instruction";
+    const options = createTestOptions({ systemPrompt: customPrompt });
+    const prompt = getSystemPrompt(options);
+
+    assert.strictEqual(prompt, customPrompt);
+  });
+});
+
+describe("provider2SummarizeAgent", () => {
+  it("should have openai config", () => {
+    const config = provider2SummarizeAgent.openai;
+    assert.strictEqual(config.agentName, "openAIAgent");
+    assert.strictEqual(config.keyName, "OPENAI_API_KEY");
+    assert.ok(config.defaultModel);
+  });
+
+  it("should have anthropic config", () => {
+    const config = provider2SummarizeAgent.anthropic;
+    assert.strictEqual(config.agentName, "anthropicAgent");
+    assert.strictEqual(config.keyName, "ANTHROPIC_API_KEY");
+    assert.ok(config.defaultModel);
+  });
+
+  it("should have groq config", () => {
+    const config = provider2SummarizeAgent.groq;
+    assert.strictEqual(config.agentName, "groqAgent");
+    assert.strictEqual(config.keyName, "GROQ_API_KEY");
+    assert.ok(config.defaultModel);
+  });
+
+  it("should have gemini config", () => {
+    const config = provider2SummarizeAgent.gemini;
+    assert.strictEqual(config.agentName, "geminiAgent");
+    assert.strictEqual(config.keyName, "GEMINI_API_KEY");
+    assert.ok(config.defaultModel);
+  });
+});
+
+describe("getProviderConfig", () => {
+  it("should return correct config for provider", () => {
+    const openaiConfig = getProviderConfig("openai");
+    assert.strictEqual(openaiConfig.agentName, "openAIAgent");
+
+    const anthropicConfig = getProviderConfig("anthropic");
+    assert.strictEqual(anthropicConfig.agentName, "anthropicAgent");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,6 +1482,11 @@ dotenv@^17.2.3:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
   integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
 
+dotenv@^17.2.4:
+  version "17.2.4"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.4.tgz#b5a0e2f015e0be287a5330a90bf0e804606504c2"
+  integrity sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,10 +709,10 @@
     "@types/node" "*"
     form-data "^4.0.4"
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^25.2.0":
-  version "25.2.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.0.tgz#015b7d228470c1dcbfc17fe9c63039d216b4d782"
-  integrity sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^25.2.1":
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.1.tgz#378021f9e765bb65ba36de16f3c3a8622c1fa03d"
+  integrity sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==
   dependencies:
     undici-types "~7.16.0"
 
@@ -1477,12 +1477,7 @@ dfa@^1.2.0:
   resolved "https://registry.yarnpkg.com/dfa/-/dfa-1.2.0.tgz#96ac3204e2d29c49ea5b57af8d92c2ae12790657"
   integrity sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==
 
-dotenv@^17.2.3:
-  version "17.2.3"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
-  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
-
-dotenv@^17.2.4:
+dotenv@^17.2.3, dotenv@^17.2.4:
   version "17.2.4"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.4.tgz#b5a0e2f015e0be287a5330a90bf0e804606504c2"
   integrity sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==


### PR DESCRIPTION
## Summary

- Add `summarize` CLI command that generates human-readable summaries of MulmoScript content
- Support text format (default) and markdown format output
- Use GraphAI with multiple LLM provider support (OpenAI, Anthropic, Groq, Gemini)

## Features

- **Text format**: Plain text summary of the script content
- **Markdown format**: Structured summary with title, overview, key points, and conclusion
- **Provider support**: OpenAI (default), Anthropic, Groq, Gemini
- **Filtering**: Section and tag filtering to summarize specific parts

## Usage

```bash
# Generate text summary (default)
mulmocast-preprocessor summarize script.json

# Generate markdown summary
mulmocast-preprocessor summarize script.json --format markdown

# Use different provider
mulmocast-preprocessor summarize script.json --provider anthropic

# Summarize specific section
mulmocast-preprocessor summarize script.json -s chapter1
```

## Test plan

- [x] Unit tests for prompt building and provider config
- [x] Manual test with text format output
- [x] Manual test with markdown format output
- [x] `yarn build`, `yarn lint`, `yarn test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)