### PR TITLE
feat(preprocessor): add language option and URL support for summarize

### DIFF
--- a/packages/mulmocast-preprocessor/src/cli/commands/summarize.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/summarize.ts
@@ -8,6 +8,7 @@ interface SummarizeCommandOptions {
   provider?: LLMProvider;
   model?: string;
   format?: SummarizeFormat;
+  lang?: string;
   targetLength?: number;
   systemPrompt?: string;
   verbose?: boolean;
@@ -16,17 +17,54 @@ interface SummarizeCommandOptions {
 }
 
 /**
+ * Check if input is a URL
+ */
+const isUrl = (input: string): boolean => {
+  return input.startsWith("http://") || input.startsWith("https://");
+};
+
+/**
+ * Fetch JSON from URL with timeout
+ */
+const fetchJson = async (url: string): Promise<ExtendedScript> => {
+  const controller = new AbortController();
+  const timeout_ms = 30000;
+  const timeoutId = setTimeout(() => controller.abort(), timeout_ms);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as ExtendedScript;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+/**
+ * Load script from file path or URL
+ */
+const loadScript = async (input: string): Promise<ExtendedScript> => {
+  if (isUrl(input)) {
+    return fetchJson(input);
+  }
+  const content = readFileSync(input, "utf-8");
+  return JSON.parse(content) as ExtendedScript;
+};
+
+/**
  * Summarize command handler - outputs summary to stdout
  */
 export const summarizeCommand = async (scriptPath: string, options: SummarizeCommandOptions): Promise<void> => {
   try {
-    const content = readFileSync(scriptPath, "utf-8");
-    const script: ExtendedScript = JSON.parse(content);
+    const script = await loadScript(scriptPath);
 
     const result = await summarizeScript(script, {
       provider: options.provider ?? "openai",
       model: options.model,
       format: options.format ?? "text",
+      lang: options.lang,
       targetLengthChars: options.targetLength,
       systemPrompt: options.systemPrompt,
       verbose: options.verbose ?? false,

--- a/packages/mulmocast-preprocessor/src/cli/index.ts
+++ b/packages/mulmocast-preprocessor/src/cli/index.ts
@@ -68,7 +68,7 @@ yargs(hideBin(process.argv))
     (builder) =>
       builder
         .positional("script", {
-          describe: "Path to MulmoScript JSON file",
+          describe: "Path or URL to MulmoScript JSON file",
           type: "string",
           demandOption: true,
         })
@@ -87,6 +87,11 @@ yargs(hideBin(process.argv))
           describe: "Output format (text, markdown)",
           type: "string",
           default: "text",
+        })
+        .option("lang", {
+          alias: "l",
+          describe: "Output language (e.g., ja, en, zh)",
+          type: "string",
         })
         .option("target-length", {
           describe: "Target summary length in characters",
@@ -117,6 +122,7 @@ yargs(hideBin(process.argv))
         provider: argv.provider as LLMProvider,
         model: argv.model,
         format: argv.format as SummarizeFormat,
+        lang: argv.lang,
         targetLength: argv.targetLength,
         systemPrompt: argv.systemPrompt,
         verbose: argv.verbose,
@@ -133,8 +139,8 @@ yargs(hideBin(process.argv))
   .example("$0 profiles script.json", "List all available profiles")
   .example("$0 summarize script.json", "Generate text summary with OpenAI")
   .example("$0 summarize script.json --format markdown", "Generate markdown summary")
-  .example("$0 summarize script.json --provider anthropic", "Use Anthropic for summary")
-  .example("$0 summarize script.json -s chapter1", "Summarize specific section")
+  .example("$0 summarize script.json -l ja", "Output summary in Japanese")
+  .example("$0 summarize https://example.com/script.json", "Summarize from URL")
   .help()
   .alias("h", "help")
   .version()

--- a/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/summarize/prompts.ts
@@ -66,11 +66,39 @@ export const buildUserPrompt = (script: ExtendedScript, options: SummarizeOption
 };
 
 /**
- * Get system prompt based on format
+ * Get language name from code
+ */
+const getLanguageName = (langCode: string): string => {
+  const langMap: Record<string, string> = {
+    ja: "Japanese",
+    en: "English",
+    zh: "Chinese",
+    ko: "Korean",
+    fr: "French",
+    de: "German",
+    es: "Spanish",
+    it: "Italian",
+    pt: "Portuguese",
+    ru: "Russian",
+  };
+  return langMap[langCode] || langCode;
+};
+
+/**
+ * Get system prompt based on format and language
  */
 export const getSystemPrompt = (options: SummarizeOptions): string => {
   if (options.systemPrompt) {
     return options.systemPrompt;
   }
-  return options.format === "markdown" ? DEFAULT_SYSTEM_PROMPT_MARKDOWN : DEFAULT_SYSTEM_PROMPT_TEXT;
+
+  const basePrompt = options.format === "markdown" ? DEFAULT_SYSTEM_PROMPT_MARKDOWN : DEFAULT_SYSTEM_PROMPT_TEXT;
+
+  // Add language instruction if specified
+  if (options.lang) {
+    const langName = getLanguageName(options.lang);
+    return `${basePrompt}\n- IMPORTANT: Write the output in ${langName}`;
+  }
+
+  return basePrompt;
 };

--- a/packages/mulmocast-preprocessor/src/types/summarize.ts
+++ b/packages/mulmocast-preprocessor/src/types/summarize.ts
@@ -25,6 +25,9 @@ export const summarizeOptionsSchema = z.object({
   // Output format
   format: summarizeFormatSchema.default("text"),
 
+  // Output language (e.g., "ja", "en", "fr")
+  lang: z.string().optional(),
+
   // Target length (optional)
   targetLengthChars: z.number().positive().optional(),
 


### PR DESCRIPTION
## Summary
- Add `-l/--lang` option to specify output language (e.g., `-l ja` for Japanese)
- Support URL input to fetch MulmoScript JSON from network
- Add timeout handling (30s) for URL fetch with AbortController

## Test plan
- [x] Test language option with local file: `mulmocast-preprocessor summarize script.json -l ja`
- [x] Test URL fetch: `mulmocast-preprocessor summarize https://example.com/script.json`
- [x] Test combined: `mulmocast-preprocessor summarize https://example.com/script.json -l ja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)