### PR TITLE
refactor(preprocessor): extract common buildScriptContent function

### DIFF
--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -1,6 +1,6 @@
 import type { QueryOptions } from "../../../../types/query.js";
 import type { ExtendedScript } from "../../../../types/index.js";
-import { getLanguageName } from "../../llm.js";
+import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**
  * Default system prompt for query
@@ -36,33 +36,9 @@ export const getSystemPrompt = (options: QueryOptions): string => {
 export const buildUserPrompt = (script: ExtendedScript, question: string): string => {
   const parts: string[] = [];
 
-  // Add script metadata
-  parts.push(`# Script: ${script.title}`);
-  parts.push(`Language: ${script.lang}`);
-  parts.push("");
+  // Add common script content (title, language, sections with beats)
+  parts.push(buildScriptContent(script));
 
-  // Collect all text from beats
-  const sections = new Map<string, string[]>();
-
-  script.beats.forEach((beat, index) => {
-    const text = beat.text || "";
-    if (!text.trim()) return;
-
-    const section = beat.meta?.section || "main";
-    if (!sections.has(section)) {
-      sections.set(section, []);
-    }
-    sections.get(section)!.push(`[${index}] ${text}`);
-  });
-
-  // Output by section
-  sections.forEach((texts, section) => {
-    parts.push(`## Section: ${section}`);
-    texts.forEach((t) => parts.push(t));
-    parts.push("");
-  });
-
-  parts.push("");
   parts.push("---");
   parts.push("");
   parts.push(`Question: ${question}`);

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
@@ -1,6 +1,6 @@
 import type { SummarizeOptions } from "../../../../types/summarize.js";
 import type { ExtendedScript } from "../../../../types/index.js";
-import { getLanguageName } from "../../llm.js";
+import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**
  * Default system prompt for text summary
@@ -29,31 +29,8 @@ export const DEFAULT_SYSTEM_PROMPT_MARKDOWN = `You are creating a summary based 
 export const buildUserPrompt = (script: ExtendedScript, options: SummarizeOptions): string => {
   const parts: string[] = [];
 
-  // Add script metadata
-  parts.push(`# Script: ${script.title}`);
-  parts.push(`Language: ${script.lang}`);
-  parts.push("");
-
-  // Collect all text from beats
-  const sections = new Map<string, string[]>();
-
-  script.beats.forEach((beat, index) => {
-    const text = beat.text || "";
-    if (!text.trim()) return;
-
-    const section = beat.meta?.section || "main";
-    if (!sections.has(section)) {
-      sections.set(section, []);
-    }
-    sections.get(section)!.push(`[${index}] ${text}`);
-  });
-
-  // Output by section
-  sections.forEach((texts, section) => {
-    parts.push(`## Section: ${section}`);
-    texts.forEach((t) => parts.push(t));
-    parts.push("");
-  });
+  // Add common script content (title, language, sections with beats)
+  parts.push(buildScriptContent(script));
 
   // Add target length if specified
   if (options.targetLengthChars) {


### PR DESCRIPTION
## Summary

- Extract `buildScriptContent()` to `llm.ts` for shared script content building (title, language, sections with beats)
- Update `summarize/prompts.ts` and `query/prompts.ts` to use the shared function
- Add `CommandResult` interface and `executeCommand` helper for potential future use

This reduces code duplication (~53 lines) while preserving intentional differences between summarize and query:
- Different empty messages
- Different user prompt endings
- Different system prompt language instructions
- Different result structures

## Test plan

- [x] All existing tests pass
- [x] `yarn build` succeeds
- [x] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)