### PR TITLE
feat(preprocessor): add interactive query mode

### DIFF
--- a/packages/mulmocast-preprocessor/src/cli/commands/query.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/query.ts
@@ -1,5 +1,7 @@
+import { createInterface } from "node:readline";
 import { GraphAILogger } from "graphai";
 import { queryScript } from "../../core/ai/command/query/index.js";
+import { createInteractiveSession, sendInteractiveQuery, clearHistory } from "../../core/ai/command/query/interactive.js";
 import { loadScript } from "../utils.js";
 import type { LLMProvider } from "../../types/summarize.js";
 
@@ -11,15 +13,23 @@ interface QueryCommandOptions {
   verbose?: boolean;
   section?: string;
   tags?: string[];
+  interactive?: boolean;
 }
 
 /**
  * Query command handler - outputs answer to stdout
  */
-export const queryCommand = async (scriptPath: string, question: string, options: QueryCommandOptions): Promise<void> => {
+export const queryCommand = async (scriptPath: string, question: string | undefined, options: QueryCommandOptions): Promise<void> => {
   try {
     const script = await loadScript(scriptPath);
 
+    // Interactive mode
+    if (options.interactive || question === undefined) {
+      await runInteractiveMode(scriptPath, script, options);
+      return;
+    }
+
+    // Single query mode
     const result = await queryScript(script, question, {
       provider: options.provider ?? "openai",
       model: options.model,
@@ -40,4 +50,94 @@ export const queryCommand = async (scriptPath: string, question: string, options
     }
     process.exit(1);
   }
+};
+
+/**
+ * Run interactive query mode
+ */
+const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType<typeof loadScript>>, options: QueryCommandOptions): Promise<void> => {
+  const { session, filteredScript, validatedOptions } = createInteractiveSession(script, {
+    provider: options.provider ?? "openai",
+    model: options.model,
+    lang: options.lang,
+    systemPrompt: options.systemPrompt,
+    verbose: options.verbose ?? false,
+    section: options.section,
+    tags: options.tags,
+  });
+
+  if (filteredScript.beats.length === 0) {
+    GraphAILogger.error("No content available to query.");
+    process.exit(1);
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  GraphAILogger.info(`Interactive query mode for "${session.scriptTitle}" (${session.beatCount} beats)`);
+  GraphAILogger.info("Commands: /clear (clear history), /history (show history), /exit or Ctrl+C (quit)");
+  GraphAILogger.info("");
+
+  const prompt = (): void => {
+    rl.question("You: ", async (input) => {
+      const trimmedInput = input.trim();
+
+      if (!trimmedInput) {
+        prompt();
+        return;
+      }
+
+      // Handle commands
+      if (trimmedInput === "/exit" || trimmedInput === "/quit") {
+        GraphAILogger.info("Goodbye!");
+        rl.close();
+        return;
+      }
+
+      if (trimmedInput === "/clear") {
+        clearHistory(session);
+        GraphAILogger.info("Conversation history cleared.\n");
+        prompt();
+        return;
+      }
+
+      if (trimmedInput === "/history") {
+        if (session.history.length === 0) {
+          GraphAILogger.info("No conversation history.\n");
+        } else {
+          GraphAILogger.info("Conversation history:");
+          session.history.forEach((msg) => {
+            const prefix = msg.role === "user" ? "Q" : "A";
+            GraphAILogger.info(`${prefix}: ${msg.content}`);
+          });
+          GraphAILogger.info("");
+        }
+        prompt();
+        return;
+      }
+
+      // Send query
+      try {
+        const answer = await sendInteractiveQuery(filteredScript, trimmedInput, session, validatedOptions);
+        GraphAILogger.info(`\nAssistant: ${answer}\n`);
+      } catch (error) {
+        if (error instanceof Error) {
+          GraphAILogger.error(`Error: ${error.message}\n`);
+        } else {
+          GraphAILogger.error("Unknown error occurred\n");
+        }
+      }
+
+      prompt();
+    });
+  };
+
+  // Handle Ctrl+C
+  rl.on("close", () => {
+    process.exit(0);
+  });
+
+  prompt();
 };

--- a/packages/mulmocast-preprocessor/src/cli/index.ts
+++ b/packages/mulmocast-preprocessor/src/cli/index.ts
@@ -133,7 +133,7 @@ yargs(hideBin(process.argv))
     },
   )
   .command(
-    "query <script> <question>",
+    "query <script> [question]",
     "Ask a question about the script content",
     (builder) =>
       builder
@@ -143,9 +143,14 @@ yargs(hideBin(process.argv))
           demandOption: true,
         })
         .positional("question", {
-          describe: "Question to ask about the script",
+          describe: "Question to ask about the script (omit for interactive mode)",
           type: "string",
-          demandOption: true,
+        })
+        .option("interactive", {
+          alias: "i",
+          describe: "Start interactive query mode",
+          type: "boolean",
+          default: false,
         })
         .option("provider", {
           describe: "LLM provider (openai, anthropic, groq, gemini)",
@@ -191,6 +196,7 @@ yargs(hideBin(process.argv))
         verbose: argv.verbose,
         section: argv.section,
         tags,
+        interactive: argv.interactive,
       });
     },
   )
@@ -206,6 +212,8 @@ yargs(hideBin(process.argv))
   .example("$0 summarize https://example.com/script.json", "Summarize from URL")
   .example('$0 query script.json "What is the main topic?"', "Ask a question about the script")
   .example('$0 query script.json "登場人物は？" -l ja', "Query in Japanese")
+  .example("$0 query script.json -i", "Start interactive query mode")
+  .example("$0 query script.json", "Interactive mode (question omitted)")
   .help()
   .alias("h", "help")
   .version()

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
@@ -1,0 +1,64 @@
+import type { ExtendedScript } from "../../../../types/index.js";
+import type { QueryOptions, InteractiveQuerySession, ConversationMessage } from "../../../../types/query.js";
+import { queryOptionsSchema } from "../../../../types/query.js";
+import { executeLLM, filterScript } from "../../llm.js";
+import { buildInteractiveUserPrompt, getInteractiveSystemPrompt } from "./prompts.js";
+
+/**
+ * Create an interactive query session
+ */
+export const createInteractiveSession = (
+  script: ExtendedScript,
+  options: Partial<QueryOptions> = {},
+): { session: InteractiveQuerySession; filteredScript: ExtendedScript; validatedOptions: QueryOptions } => {
+  const validatedOptions = queryOptionsSchema.parse(options);
+  const filteredScript = filterScript(script, validatedOptions);
+  const scriptTitle = script.title || "Untitled";
+
+  const session: InteractiveQuerySession = {
+    scriptTitle,
+    beatCount: filteredScript.beats.length,
+    history: [],
+  };
+
+  return { session, filteredScript, validatedOptions };
+};
+
+/**
+ * Send a question in an interactive session
+ */
+export const sendInteractiveQuery = async (
+  filteredScript: ExtendedScript,
+  question: string,
+  session: InteractiveQuerySession,
+  options: QueryOptions,
+): Promise<string> => {
+  if (filteredScript.beats.length === 0) {
+    return "No content available to answer the question.";
+  }
+
+  const systemPrompt = getInteractiveSystemPrompt(options);
+  const userPrompt = buildInteractiveUserPrompt(filteredScript, question, session.history);
+
+  const answer = await executeLLM(systemPrompt, userPrompt, options, options.verbose ? `Interactive query: ${question}` : undefined);
+
+  // Add to history
+  session.history.push({ role: "user", content: question });
+  session.history.push({ role: "assistant", content: answer });
+
+  return answer;
+};
+
+/**
+ * Clear conversation history
+ */
+export const clearHistory = (session: InteractiveQuerySession): void => {
+  session.history = [];
+};
+
+/**
+ * Get conversation history
+ */
+export const getHistory = (session: InteractiveQuerySession): ConversationMessage[] => {
+  return [...session.history];
+};

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -1,4 +1,4 @@
-import type { QueryOptions } from "../../../../types/query.js";
+import type { QueryOptions, ConversationMessage } from "../../../../types/query.js";
 import type { ExtendedScript } from "../../../../types/index.js";
 import { getLanguageName, buildScriptContent } from "../../llm.js";
 
@@ -42,6 +42,66 @@ export const buildUserPrompt = (script: ExtendedScript, question: string): strin
   parts.push("---");
   parts.push("");
   parts.push(`Question: ${question}`);
+  parts.push("");
+  parts.push("Answer:");
+
+  return parts.join("\n");
+};
+
+/**
+ * Default system prompt for interactive query
+ */
+export const DEFAULT_INTERACTIVE_SYSTEM_PROMPT = `You are answering questions based on the content provided.
+- Answer based ONLY on the information in the provided content
+- If the answer cannot be found in the content, say so clearly
+- Be concise and direct in your answers
+- Do not make up information that is not in the content
+- You may reference previous conversation when answering follow-up questions`;
+
+/**
+ * Get system prompt for interactive mode
+ */
+export const getInteractiveSystemPrompt = (options: QueryOptions): string => {
+  if (options.systemPrompt) {
+    return options.systemPrompt;
+  }
+
+  const basePrompt = DEFAULT_INTERACTIVE_SYSTEM_PROMPT;
+
+  if (options.lang) {
+    const langName = getLanguageName(options.lang);
+    return `${basePrompt}\n- IMPORTANT: Write the answer in ${langName}`;
+  }
+
+  return basePrompt;
+};
+
+/**
+ * Build user prompt with conversation history for interactive mode
+ */
+export const buildInteractiveUserPrompt = (script: ExtendedScript, question: string, history: ConversationMessage[]): string => {
+  const parts: string[] = [];
+
+  // Add common script content (title, language, sections with beats)
+  parts.push(buildScriptContent(script));
+
+  parts.push("---");
+  parts.push("");
+
+  // Add conversation history if exists
+  if (history.length > 0) {
+    parts.push("Previous conversation:");
+    history.forEach((msg) => {
+      if (msg.role === "user") {
+        parts.push(`Q: ${msg.content}`);
+      } else {
+        parts.push(`A: ${msg.content}`);
+      }
+    });
+    parts.push("");
+  }
+
+  parts.push(`Current question: ${question}`);
   parts.push("");
   parts.push("Answer:");
 

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -7,11 +7,12 @@ export { listProfiles } from "./core/preprocessing/profiles.js";
 // AI API
 export { summarizeScript } from "./core/ai/command/summarize/index.js";
 export { queryScript } from "./core/ai/command/query/index.js";
+export { createInteractiveSession, sendInteractiveQuery, clearHistory, getHistory } from "./core/ai/command/query/interactive.js";
 
 // Types
 export type { BeatVariant, BeatMeta, ExtendedBeat, ExtendedScript, OutputProfile, ProcessOptions, ProfileInfo } from "./types/index.js";
 export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat, ProviderConfig } from "./types/summarize.js";
-export type { QueryOptions, QueryResult } from "./types/query.js";
+export type { QueryOptions, QueryResult, ConversationMessage, InteractiveQuerySession } from "./types/query.js";
 
 // Schemas (for validation)
 export { beatVariantSchema, beatMetaSchema, extendedBeatSchema, extendedScriptSchema, outputProfileSchema } from "./types/index.js";

--- a/packages/mulmocast-preprocessor/src/types/query.ts
+++ b/packages/mulmocast-preprocessor/src/types/query.ts
@@ -35,3 +35,20 @@ export interface QueryResult {
   scriptTitle: string;
   beatCount: number;
 }
+
+/**
+ * Conversation message for interactive query
+ */
+export interface ConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Interactive query session state
+ */
+export interface InteractiveQuerySession {
+  scriptTitle: string;
+  beatCount: number;
+  history: ConversationMessage[];
+}


### PR DESCRIPTION
## Summary

- Add `-i/--interactive` flag to query command for interactive Q&A mode
- Support omitting question argument to automatically enter interactive mode
- Maintain conversation history for context-aware follow-up questions
- Built-in commands: `/clear` (clear history), `/history` (show history), `/exit` (quit)
- Export interactive session API for programmatic use

## Test plan

- [x] All existing tests pass
- [x] `yarn build` succeeds
- [x] `yarn lint` passes
- [x] Manual test with actual LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)