### PR TITLE
feat(preprocessor): add scriptMeta schema and reference URL fetching

### DIFF
--- a/packages/mulmocast-preprocessor/samples/graphai-introduction-ja.json
+++ b/packages/mulmocast-preprocessor/samples/graphai-introduction-ja.json
@@ -127,5 +127,52 @@
     "teaser": {
       "description": "ティーザー版"
     }
+  },
+  "scriptMeta": {
+    "audience": "AIシステム開発者、バックエンドエンジニア、LLMアプリケーション開発に興味のある方",
+    "prerequisites": ["JavaScript/TypeScriptの基本知識", "非同期処理の理解", "LLM APIの基本的な知識"],
+    "goals": [
+      "GraphAIの基本概念（ノード、エージェント、グラフ）を理解する",
+      "データフローベースのAIオーケストレーションの利点を学ぶ",
+      "実際のユースケースでGraphAIを活用できるようになる"
+    ],
+    "background": "GraphAIは、複数のAIエージェントやAPIを効率的に連携させるためのフレームワークです。従来の命令型プログラミングとは異なり、データの流れをグラフとして宣言的に定義することで、依存関係の自動解決と並列実行を実現します。",
+    "faq": [
+      {
+        "question": "GraphAIとLangChainの違いは？",
+        "answer": "GraphAIはDAGベースの宣言的アプローチでデータフローを定義し、自動並列化を行います。LangChainは逐次的なチェーン実行が中心で、より高レベルな抽象化を提供します。GraphAIは純粋関数としてのエージェント設計を重視し、テスト容易性と再利用性を高めています。"
+      },
+      {
+        "question": "GraphAIはどんなユースケースに向いている？",
+        "answer": "複数LLMの並列呼び出し、大量データのバッチ処理、複雑なワークフローの構築、A/Bテストなどに適しています。特にAPI呼び出しの並列化やレート制限の制御が必要な場面で威力を発揮します。"
+      },
+      {
+        "question": "商用利用は可能？",
+        "answer": "はい、GraphAIはMITライセンスで提供されており、商用利用も可能です。本番環境での使用実績もあります。"
+      }
+    ],
+    "keywords": ["GraphAI", "AIオーケストレーション", "データフロー", "DAG", "エージェント", "並列処理", "TypeScript"],
+    "references": [
+      {
+        "type": "code",
+        "url": "https://github.com/receptron/graphai",
+        "title": "GraphAI GitHub Repository",
+        "description": "GraphAIの公式リポジトリ。ソースコード、ドキュメント、サンプルが含まれています。"
+      },
+      {
+        "type": "web",
+        "url": "https://www.npmjs.com/package/graphai",
+        "title": "GraphAI npm package",
+        "description": "npmパッケージページ。インストール方法と基本的な使い方が記載されています。"
+      },
+      {
+        "type": "document",
+        "url": "https://github.com/receptron/graphai/blob/main/docs/agentDocs/README.md",
+        "title": "GraphAI Agents Documentation",
+        "description": "標準エージェントの一覧と使い方のドキュメント。"
+      }
+    ],
+    "author": "receptron",
+    "version": "1.0.0"
   }
 }

--- a/packages/mulmocast-preprocessor/samples/llm-agent-patterns-en.json
+++ b/packages/mulmocast-preprocessor/samples/llm-agent-patterns-en.json
@@ -136,5 +136,58 @@
     "summary": {
       "description": "Condensed version"
     }
+  },
+  "scriptMeta": {
+    "audience": "AI engineers, software architects, developers building LLM-powered applications",
+    "prerequisites": ["Basic understanding of LLMs and APIs", "Familiarity with async programming", "Basic knowledge of system design"],
+    "goals": [
+      "Understand the key architectural patterns for LLM agents",
+      "Learn when to apply ReAct, Plan-and-Execute, and other patterns",
+      "Implement safe and effective agent systems in production"
+    ],
+    "background": "LLM agents represent a paradigm shift from simple chatbots to autonomous AI systems capable of planning, tool use, and learning from experience. This content covers the foundational patterns that power modern agent frameworks like AutoGPT, LangChain agents, and Claude Computer Use.",
+    "faq": [
+      {
+        "question": "Which pattern should I start with?",
+        "answer": "Start with ReAct for most use cases. It's simple, interpretable, and recovers well from errors. Move to Plan-and-Execute only when you have complex multi-step tasks where upfront planning provides clear benefits."
+      },
+      {
+        "question": "How do I handle agent failures in production?",
+        "answer": "Implement multiple layers: 1) Retry with exponential backoff for transient failures, 2) Fallback to simpler strategies, 3) Human escalation for critical paths, 4) Comprehensive logging for debugging. Use frameworks like LangSmith for observability."
+      },
+      {
+        "question": "What's the best way to implement memory?",
+        "answer": "Start with conversation history (short-term). Add vector database retrieval (RAG) when you need to access larger knowledge bases. Consider episodic memory only for agents that need to learn from their own experiences over time."
+      }
+    ],
+    "keywords": ["LLM agents", "ReAct", "Plan and Execute", "tool use", "memory", "multi-agent", "AI safety"],
+    "references": [
+      {
+        "type": "document",
+        "url": "https://arxiv.org/abs/2210.03629",
+        "title": "ReAct: Synergizing Reasoning and Acting in Language Models",
+        "description": "The original ReAct paper by Yao et al. (2022) that introduced the reasoning + acting pattern."
+      },
+      {
+        "type": "document",
+        "url": "https://arxiv.org/abs/2303.11366",
+        "title": "Reflexion: Language Agents with Verbal Reinforcement Learning",
+        "description": "Paper introducing episodic memory and self-reflection for agent improvement."
+      },
+      {
+        "type": "code",
+        "url": "https://github.com/langchain-ai/langchain",
+        "title": "LangChain Repository",
+        "description": "Popular framework implementing various agent patterns with extensive documentation."
+      },
+      {
+        "type": "web",
+        "url": "https://www.anthropic.com/news/tool-use-ga",
+        "title": "Anthropic Tool Use Documentation",
+        "description": "Official documentation for implementing tool use with Claude models."
+      }
+    ],
+    "author": "AI Architecture Team",
+    "version": "1.0.0"
   }
 }

--- a/packages/mulmocast-preprocessor/samples/mulmocast-overview-en.json
+++ b/packages/mulmocast-preprocessor/samples/mulmocast-overview-en.json
@@ -139,5 +139,62 @@
     "teaser": {
       "description": "Short promotional version"
     }
+  },
+  "scriptMeta": {
+    "audience": "Content creators, developers, marketers who want to automate presentation and video creation",
+    "prerequisites": ["Basic JSON knowledge", "Familiarity with command-line tools", "Understanding of API keys and environment variables"],
+    "goals": [
+      "Understand MulmoCast's capabilities and MulmoScript format",
+      "Learn to create presentations with AI-generated speech and images",
+      "Integrate MulmoCast into automated content pipelines"
+    ],
+    "background": "MulmoCast is an open-source tool that transforms JSON scripts into professional presentations with AI-generated speech and images. It supports multiple TTS providers (OpenAI, ElevenLabs, Google, VOICEVOX) and image generators (DALL-E, Stable Diffusion), enabling automated content creation at scale.",
+    "faq": [
+      {
+        "question": "What TTS providers does MulmoCast support?",
+        "answer": "MulmoCast supports OpenAI TTS (alloy, echo, fable, nova, onyx, shimmer voices), ElevenLabs (including custom voice cloning), Google Text-to-Speech, and VOICEVOX for high-quality Japanese synthesis. You can mix providers within a single script."
+      },
+      {
+        "question": "Can I use MulmoCast without AI image generation?",
+        "answer": "Yes! You can provide images directly via URL or local file path. AI image generation (via imagePrompt) is optional. You can also use --speech-only flag to skip image generation entirely."
+      },
+      {
+        "question": "How does the preprocessor enhance MulmoScript?",
+        "answer": "The preprocessor adds metadata capabilities (tags, sections, context, keywords) for content organization, variant support for creating multiple versions (summary, teaser), and AI features like summarization and Q&A that use the metadata to provide intelligent responses."
+      },
+      {
+        "question": "Is MulmoCast suitable for production use?",
+        "answer": "Yes, MulmoCast is MIT licensed and designed for production use. It includes incremental generation to save API costs, caching for images and speech, and supports parallel processing for efficiency. Many organizations use it for automated content pipelines."
+      }
+    ],
+    "keywords": ["MulmoCast", "MulmoScript", "AI presentation", "TTS", "text-to-speech", "image generation", "automation"],
+    "references": [
+      {
+        "type": "code",
+        "url": "https://github.com/receptron/mulmocast",
+        "title": "MulmoCast GitHub Repository",
+        "description": "Official MulmoCast repository with source code, documentation, and examples."
+      },
+      {
+        "type": "web",
+        "url": "https://www.npmjs.com/package/mulmocast",
+        "title": "MulmoCast npm package",
+        "description": "npm package page with installation instructions and basic usage."
+      },
+      {
+        "type": "code",
+        "url": "https://github.com/receptron/mulmocast-cli",
+        "title": "MulmoCast CLI Repository",
+        "description": "Command-line interface for MulmoCast with additional features and integrations."
+      },
+      {
+        "type": "document",
+        "url": "https://github.com/receptron/graphai",
+        "title": "GraphAI Framework",
+        "description": "The underlying AI orchestration framework that powers MulmoCast's workflow capabilities."
+      }
+    ],
+    "author": "receptron",
+    "version": "1.0.0"
   }
 }

--- a/packages/mulmocast-preprocessor/samples/typescript-patterns-ja.json
+++ b/packages/mulmocast-preprocessor/samples/typescript-patterns-ja.json
@@ -139,5 +139,62 @@
     "beginner": {
       "description": "初心者向け"
     }
+  },
+  "scriptMeta": {
+    "audience": "JavaScriptからTypeScriptへの移行を考えている開発者、型安全なコードを書きたいフロントエンド/バックエンドエンジニア",
+    "prerequisites": ["JavaScriptの基本知識", "関数、オブジェクト、配列の理解", "npmの基本的な使い方"],
+    "goals": [
+      "TypeScriptの型システムの基本を理解する",
+      "実践的なパターン（Discriminated Union、ジェネリクス等）を習得する",
+      "strictモードとユーティリティ型を活用した型安全なコードを書けるようになる"
+    ],
+    "background": "TypeScriptはMicrosoftが開発したJavaScriptのスーパーセットで、静的型付けによりバグを事前に防ぎ、IDEの補完機能を強化します。現在、多くの企業やOSSプロジェクトで採用されており、フロントエンドからバックエンドまで幅広く使用されています。",
+    "faq": [
+      {
+        "question": "既存のJSプロジェクトをTSに移行するには？",
+        "answer": "段階的な移行がおすすめです。まずtsconfig.jsonでallowJs: trueを設定し、.jsファイルをそのまま使用可能にします。次に重要なファイルから.tsに変換し、strict: falseから始めて徐々にオプションを有効化していきます。"
+      },
+      {
+        "question": "interfaceとtypeどちらを使うべき？",
+        "answer": "チームで統一することが最も重要です。一般的なガイドライン: オブジェクトの形状定義にはinterface（拡張可能）、ユニオン型やマップ型にはtype（柔軟性が高い）。TypeScript公式はどちらでも良いとしています。"
+      },
+      {
+        "question": "anyを避けるべき理由は？",
+        "answer": "anyは型チェックを完全に無効化するため、TypeScriptを使う意味がなくなります。代わりにunknownを使い、使用前に型ガードで絞り込むことで、型安全性を維持できます。"
+      },
+      {
+        "question": "Zodと他のバリデーションライブラリの違いは？",
+        "answer": "ZodはTypeScript-firstで設計されており、z.infer<>で型推論ができます。Yupは主にJavaScript向け、io-tsは関数型プログラミングスタイル、Valibotは軽量なバンドルサイズが特徴です。"
+      }
+    ],
+    "keywords": ["TypeScript", "型安全", "静的型付け", "ジェネリクス", "Zod", "strictモード", "ユーティリティ型"],
+    "references": [
+      {
+        "type": "document",
+        "url": "https://www.typescriptlang.org/docs/handbook/intro.html",
+        "title": "TypeScript Handbook",
+        "description": "TypeScript公式ハンドブック。基本から応用まで網羅的に解説されています。"
+      },
+      {
+        "type": "code",
+        "url": "https://github.com/type-challenges/type-challenges",
+        "title": "Type Challenges",
+        "description": "TypeScriptの型パズル集。実践的な型の書き方を学べます。"
+      },
+      {
+        "type": "web",
+        "url": "https://zod.dev/",
+        "title": "Zod Documentation",
+        "description": "Zodの公式ドキュメント。TypeScript-firstなスキーマバリデーションライブラリ。"
+      },
+      {
+        "type": "document",
+        "url": "https://www.typescriptlang.org/tsconfig",
+        "title": "TSConfig Reference",
+        "description": "tsconfig.jsonの全オプションのリファレンス。strictモードの詳細も記載。"
+      }
+    ],
+    "author": "TypeScript Educator",
+    "version": "1.0.0"
   }
 }

--- a/packages/mulmocast-preprocessor/src/cli/commands/query.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/query.ts
@@ -1,9 +1,18 @@
 import { createInterface } from "node:readline";
 import { GraphAILogger } from "graphai";
 import { queryScript } from "../../core/ai/command/query/index.js";
-import { createInteractiveSession, sendInteractiveQuery, clearHistory } from "../../core/ai/command/query/interactive.js";
+import {
+  createInteractiveSession,
+  sendInteractiveQuery,
+  sendInteractiveQueryWithFetch,
+  clearHistory,
+  getReferences,
+  fetchReference,
+  parseSuggestedFetch,
+} from "../../core/ai/command/query/interactive.js";
 import { loadScript } from "../utils.js";
 import type { LLMProvider } from "../../types/summarize.js";
+import type { Reference } from "../../types/index.js";
 
 interface QueryCommandOptions {
   provider?: LLMProvider;
@@ -53,6 +62,13 @@ export const queryCommand = async (scriptPath: string, question: string | undefi
 };
 
 /**
+ * Format references for display
+ */
+const formatReferences = (references: Reference[]): string => {
+  return references.map((ref, i) => `  ${i + 1}. [${ref.type || "web"}] ${ref.title || ref.url}`).join("\n");
+};
+
+/**
  * Run interactive query mode
  */
 const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType<typeof loadScript>>, options: QueryCommandOptions): Promise<void> => {
@@ -71,14 +87,21 @@ const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType
     process.exit(1);
   }
 
+  const references = getReferences(script);
+
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   GraphAILogger.info(`Interactive query mode for "${session.scriptTitle}" (${session.beatCount} beats)`);
-  GraphAILogger.info("Commands: /clear (clear history), /history (show history), /exit or Ctrl+C (quit)");
+  GraphAILogger.info("Commands: /clear (clear history), /history (show history), /refs (show references), /fetch <url> (fetch URL), /exit (quit)");
+  if (references.length > 0) {
+    GraphAILogger.info(`Available references: ${references.length}`);
+  }
   GraphAILogger.info("");
+
+  let lastSuggestedUrl: string | null = null;
 
   const prompt = (): void => {
     rl.question("You: ", async (input) => {
@@ -98,6 +121,7 @@ const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType
 
       if (trimmedInput === "/clear") {
         clearHistory(session);
+        lastSuggestedUrl = null;
         GraphAILogger.info("Conversation history cleared.\n");
         prompt();
         return;
@@ -118,10 +142,77 @@ const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType
         return;
       }
 
+      if (trimmedInput === "/refs" || trimmedInput === "/references") {
+        if (references.length === 0) {
+          GraphAILogger.info("No references available.\n");
+        } else {
+          GraphAILogger.info("Available references:");
+          GraphAILogger.info(formatReferences(references));
+          GraphAILogger.info("");
+        }
+        prompt();
+        return;
+      }
+
+      // Handle /fetch command
+      if (trimmedInput.startsWith("/fetch")) {
+        const urlArg = trimmedInput.replace(/^\/fetch\s*/, "").trim();
+        const urlToFetch = urlArg || lastSuggestedUrl;
+
+        if (!urlToFetch) {
+          GraphAILogger.info("Usage: /fetch <url> or /fetch (to fetch last suggested URL)\n");
+          prompt();
+          return;
+        }
+
+        GraphAILogger.info(`Fetching: ${urlToFetch}...`);
+        try {
+          const fetchedContent = await fetchReference(urlToFetch, validatedOptions.verbose);
+          if (fetchedContent.error) {
+            GraphAILogger.error(`Fetch error: ${fetchedContent.error}\n`);
+          } else {
+            GraphAILogger.info(`Fetched ${fetchedContent.content.length} chars from ${fetchedContent.title || urlToFetch}`);
+            GraphAILogger.info("Content loaded. Ask a question to use this reference.\n");
+
+            // Store for next query
+            session.fetchedContent = fetchedContent;
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            GraphAILogger.error(`Fetch error: ${error.message}\n`);
+          } else {
+            GraphAILogger.error("Unknown fetch error\n");
+          }
+        }
+        prompt();
+        return;
+      }
+
       // Send query
       try {
-        const answer = await sendInteractiveQuery(filteredScript, trimmedInput, session, validatedOptions);
-        GraphAILogger.info(`\nAssistant: ${answer}\n`);
+        let answer: string;
+
+        // If we have fetched content, use it
+        if (session.fetchedContent) {
+          answer = await sendInteractiveQueryWithFetch(filteredScript, trimmedInput, session.fetchedContent, session, validatedOptions);
+          // Clear fetched content after use
+          session.fetchedContent = undefined;
+        } else {
+          answer = await sendInteractiveQuery(filteredScript, trimmedInput, session, validatedOptions);
+        }
+
+        // Check for suggested fetch URL
+        const suggestedUrl = parseSuggestedFetch(answer);
+        if (suggestedUrl) {
+          lastSuggestedUrl = suggestedUrl;
+          // Remove the suggestion marker from displayed answer (bounded quantifier to prevent ReDoS)
+          const cleanAnswer = answer.replace(/\[SUGGEST_FETCH:\s*[^\]]{1,2000}\]/g, "").trim();
+          GraphAILogger.info(`\nAssistant: ${cleanAnswer}`);
+          GraphAILogger.info(`\n(Suggested reference: ${suggestedUrl})`);
+          GraphAILogger.info("Type /fetch to load this reference for more details.\n");
+        } else {
+          GraphAILogger.info(`\nAssistant: ${answer}\n`);
+        }
       } catch (error) {
         if (error instanceof Error) {
           GraphAILogger.error(`Error: ${error.message}\n`);

--- a/packages/mulmocast-preprocessor/src/cli/commands/query.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/query.ts
@@ -9,6 +9,7 @@ import {
   getReferences,
   fetchReference,
   parseSuggestedFetch,
+  removeSuggestFetchMarkers,
 } from "../../core/ai/command/query/interactive.js";
 import { loadScript } from "../utils.js";
 import type { LLMProvider } from "../../types/summarize.js";
@@ -205,8 +206,7 @@ const runInteractiveMode = async (scriptPath: string, script: Awaited<ReturnType
         const suggestedUrl = parseSuggestedFetch(answer);
         if (suggestedUrl) {
           lastSuggestedUrl = suggestedUrl;
-          // Remove the suggestion marker from displayed answer (bounded quantifier to prevent ReDoS)
-          const cleanAnswer = answer.replace(/\[SUGGEST_FETCH:\s*[^\]]{1,2000}\]/g, "").trim();
+          const cleanAnswer = removeSuggestFetchMarkers(answer);
           GraphAILogger.info(`\nAssistant: ${cleanAnswer}`);
           GraphAILogger.info(`\n(Suggested reference: ${suggestedUrl})`);
           GraphAILogger.info("Type /fetch to load this reference for more details.\n");

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
@@ -65,12 +65,24 @@ export const getHistory = (session: InteractiveQuerySession): ConversationMessag
 };
 
 /**
+ * Regex pattern for SUGGEST_FETCH marker (bounded quantifier to prevent ReDoS)
+ */
+export const SUGGEST_FETCH_PATTERN = /\[SUGGEST_FETCH:\s*([^\]]{1,2000})\]/;
+export const SUGGEST_FETCH_PATTERN_GLOBAL = /\[SUGGEST_FETCH:\s*[^\]]{1,2000}\]/g;
+
+/**
  * Parse suggested fetch URL from AI response
  */
 export const parseSuggestedFetch = (response: string): string | null => {
-  // Use bounded quantifier to prevent ReDoS
-  const match = response.match(/\[SUGGEST_FETCH:\s*([^\]]{1,2000})\]/);
+  const match = response.match(SUGGEST_FETCH_PATTERN);
   return match ? match[1].trim() : null;
+};
+
+/**
+ * Remove SUGGEST_FETCH markers from response
+ */
+export const removeSuggestFetchMarkers = (response: string): string => {
+  return response.replace(SUGGEST_FETCH_PATTERN_GLOBAL, "").trim();
 };
 
 /**

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
@@ -1,8 +1,9 @@
-import type { ExtendedScript } from "../../../../types/index.js";
+import type { ExtendedScript, Reference } from "../../../../types/index.js";
 import type { QueryOptions, InteractiveQuerySession, ConversationMessage } from "../../../../types/query.js";
 import { queryOptionsSchema } from "../../../../types/query.js";
-import { executeLLM, filterScript } from "../../llm.js";
-import { buildInteractiveUserPrompt, getInteractiveSystemPrompt } from "./prompts.js";
+import { executeLLM, filterScript, getLanguageName } from "../../llm.js";
+import { buildInteractiveUserPrompt, getInteractiveSystemPrompt, DEFAULT_INTERACTIVE_SYSTEM_PROMPT_WITH_FETCH } from "./prompts.js";
+import { fetchUrlContent, findMatchingReference, type FetchedContent } from "../../utils/fetcher.js";
 
 /**
  * Create an interactive query session
@@ -61,4 +62,88 @@ export const clearHistory = (session: InteractiveQuerySession): void => {
  */
 export const getHistory = (session: InteractiveQuerySession): ConversationMessage[] => {
   return [...session.history];
+};
+
+/**
+ * Parse suggested fetch URL from AI response
+ */
+export const parseSuggestedFetch = (response: string): string | null => {
+  // Use bounded quantifier to prevent ReDoS
+  const match = response.match(/\[SUGGEST_FETCH:\s*([^\]]{1,2000})\]/);
+  return match ? match[1].trim() : null;
+};
+
+/**
+ * Get available references from script
+ */
+export const getReferences = (script: ExtendedScript): Reference[] => {
+  return script.scriptMeta?.references || [];
+};
+
+/**
+ * Fetch reference content by URL
+ */
+export const fetchReference = async (url: string, verbose = false): Promise<FetchedContent> => {
+  return fetchUrlContent(url, 8000, verbose);
+};
+
+/**
+ * Find matching reference for a query
+ */
+export const findReference = (script: ExtendedScript, query: string): Reference | null => {
+  const references = getReferences(script);
+  return findMatchingReference(references, query);
+};
+
+/**
+ * Send a question with fetched reference content
+ */
+export const sendInteractiveQueryWithFetch = async (
+  filteredScript: ExtendedScript,
+  question: string,
+  fetchedContent: FetchedContent,
+  session: InteractiveQuerySession,
+  options: QueryOptions,
+): Promise<string> => {
+  if (filteredScript.beats.length === 0) {
+    return "No content available to answer the question.";
+  }
+
+  // Build system prompt for fetched content mode
+  let systemPrompt = DEFAULT_INTERACTIVE_SYSTEM_PROMPT_WITH_FETCH;
+  if (options.lang) {
+    const langName = getLanguageName(options.lang);
+    systemPrompt = `${systemPrompt}\n- IMPORTANT: Write the answer in ${langName}`;
+  }
+
+  // Build user prompt with fetched content
+  const baseUserPrompt = buildInteractiveUserPrompt(filteredScript, question, session.history);
+
+  // Insert fetched content before the question
+  const fetchedSection = [
+    "",
+    "---",
+    "Additional reference content fetched from URL:",
+    `URL: ${fetchedContent.url}`,
+    fetchedContent.title ? `Title: ${fetchedContent.title}` : "",
+    "",
+    fetchedContent.content,
+    "---",
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  // Insert before "Current question:" or at the end
+  const insertPoint = baseUserPrompt.indexOf("Current question:");
+  const userPrompt =
+    insertPoint >= 0 ? baseUserPrompt.slice(0, insertPoint) + fetchedSection + baseUserPrompt.slice(insertPoint) : baseUserPrompt + fetchedSection;
+
+  const answer = await executeLLM(systemPrompt, userPrompt, options, options.verbose ? `Interactive query with fetch: ${question}` : undefined);
+
+  // Add to history (include note about fetched content)
+  session.history.push({ role: "user", content: `${question} (with reference: ${fetchedContent.url})` });
+  session.history.push({ role: "assistant", content: answer });
+
+  return answer;
 };

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -56,7 +56,20 @@ export const DEFAULT_INTERACTIVE_SYSTEM_PROMPT = `You are answering questions ba
 - If the answer cannot be found in the content, say so clearly
 - Be concise and direct in your answers
 - Do not make up information that is not in the content
-- You may reference previous conversation when answering follow-up questions`;
+- You may reference previous conversation when answering follow-up questions
+- If references are available and the user asks for more details, mention which reference could provide more information
+- When you suggest fetching a reference for more details, include [SUGGEST_FETCH: <url>] in your response`;
+
+/**
+ * Default system prompt for interactive query with fetched content
+ */
+export const DEFAULT_INTERACTIVE_SYSTEM_PROMPT_WITH_FETCH = `You are answering questions based on the content provided, including fetched reference content.
+- Answer based on both the main content and any fetched reference content
+- If the answer cannot be found, say so clearly
+- Be concise and direct in your answers
+- Do not make up information
+- You may reference previous conversation when answering follow-up questions
+- Prioritize information from fetched content when it's more detailed and relevant`;
 
 /**
  * Get system prompt for interactive mode

--- a/packages/mulmocast-preprocessor/src/core/ai/llm.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/llm.ts
@@ -180,15 +180,82 @@ const buildBeatContent = (beat: ExtendedScript["beats"][number], index: number):
 };
 
 /**
+ * Build script-level metadata section
+ */
+const buildScriptMetaContent = (script: ExtendedScript): string => {
+  const meta = script.scriptMeta;
+  if (!meta) return "";
+
+  const lines: string[] = [];
+
+  // Background info
+  if (meta.background) {
+    lines.push(`Background: ${meta.background}`);
+  }
+
+  // Audience and prerequisites
+  if (meta.audience) {
+    lines.push(`Target audience: ${meta.audience}`);
+  }
+  if (meta.prerequisites && meta.prerequisites.length > 0) {
+    lines.push(`Prerequisites: ${meta.prerequisites.join(", ")}`);
+  }
+
+  // Goals
+  if (meta.goals && meta.goals.length > 0) {
+    lines.push(`Goals: ${meta.goals.join("; ")}`);
+  }
+
+  // Keywords
+  if (meta.keywords && meta.keywords.length > 0) {
+    lines.push(`Keywords: ${meta.keywords.join(", ")}`);
+  }
+
+  // References
+  if (meta.references && meta.references.length > 0) {
+    lines.push("References:");
+    meta.references.forEach((ref) => {
+      const title = ref.title || ref.url;
+      const desc = ref.description ? ` - ${ref.description}` : "";
+      lines.push(`  - [${ref.type || "web"}] ${title}: ${ref.url}${desc}`);
+    });
+  }
+
+  // FAQ
+  if (meta.faq && meta.faq.length > 0) {
+    lines.push("FAQ:");
+    meta.faq.forEach((faq) => {
+      lines.push(`  Q: ${faq.question}`);
+      lines.push(`  A: ${faq.answer}`);
+    });
+  }
+
+  // Author info
+  if (meta.author) {
+    lines.push(`Author: ${meta.author}`);
+  }
+
+  return lines.length > 0 ? lines.join("\n") : "";
+};
+
+/**
  * Build script content for user prompt (common part)
  */
 export const buildScriptContent = (script: ExtendedScript): string => {
   const parts: string[] = [];
 
-  // Add script metadata
+  // Add script title and language
   parts.push(`# Script: ${script.title}`);
   parts.push(`Language: ${script.lang}`);
   parts.push("");
+
+  // Add script-level metadata
+  const scriptMetaContent = buildScriptMetaContent(script);
+  if (scriptMetaContent) {
+    parts.push("## About this content");
+    parts.push(scriptMetaContent);
+    parts.push("");
+  }
 
   // Collect all content from beats grouped by section
   const sections = new Map<string, string[]>();

--- a/packages/mulmocast-preprocessor/src/core/ai/utils/fetcher.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/utils/fetcher.ts
@@ -1,0 +1,159 @@
+import { GraphAILogger } from "graphai";
+
+/**
+ * Fetched content result
+ */
+export interface FetchedContent {
+  url: string;
+  title: string | null;
+  content: string;
+  error?: string;
+}
+
+/**
+ * Strip HTML tags and extract text content
+ */
+const stripHtml = (html: string): string => {
+  // Remove script and style elements
+  let text = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+
+  // Remove HTML comments
+  text = text.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Replace common block elements with newlines
+  text = text.replace(/<\/(p|div|h[1-6]|li|tr|br)[^>]*>/gi, "\n");
+
+  // Remove all remaining HTML tags
+  // eslint-disable-next-line sonarjs/slow-regex -- standard HTML tag removal pattern, safe for typical HTML
+  text = text.replace(/<[^>]*>/g, " ");
+
+  // Decode common HTML entities
+  text = text.replace(/&nbsp;/g, " ");
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+
+  // Normalize whitespace
+  text = text.replace(/\s+/g, " ");
+  text = text.replace(/\n\s*\n/g, "\n\n");
+
+  return text.trim();
+};
+
+/**
+ * Extract title from HTML
+ */
+const extractTitle = (html: string): string | null => {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match ? match[1].trim() : null;
+};
+
+/**
+ * Fetch URL content and extract text
+ */
+export const fetchUrlContent = async (url: string, maxLength = 8000, verbose = false): Promise<FetchedContent> => {
+  try {
+    if (verbose) {
+      GraphAILogger.info(`Fetching URL: ${url}`);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; MulmoCast/1.0; +https://github.com/receptron/mulmocast)",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return {
+        url,
+        title: null,
+        content: "",
+        error: `HTTP ${response.status}: ${response.statusText}`,
+      };
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+
+    // Handle non-HTML content
+    if (!contentType.includes("text/html") && !contentType.includes("application/xhtml+xml")) {
+      if (contentType.includes("text/plain")) {
+        const text = await response.text();
+        return {
+          url,
+          title: null,
+          content: text.substring(0, maxLength),
+        };
+      }
+      return {
+        url,
+        title: null,
+        content: "",
+        error: `Unsupported content type: ${contentType}`,
+      };
+    }
+
+    const html = await response.text();
+    const title = extractTitle(html);
+    const content = stripHtml(html);
+
+    // Truncate if needed
+    const truncatedContent = content.length > maxLength ? content.substring(0, maxLength) + "..." : content;
+
+    if (verbose) {
+      GraphAILogger.info(`Fetched ${content.length} chars from ${url}`);
+    }
+
+    return {
+      url,
+      title,
+      content: truncatedContent,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      url,
+      title: null,
+      content: "",
+      error: errorMessage,
+    };
+  }
+};
+
+/**
+ * Find matching reference URL from script metadata
+ */
+export const findMatchingReference = (
+  references: Array<{ url: string; title?: string; description?: string }> | undefined,
+  query: string,
+): { url: string; title?: string; description?: string } | null => {
+  if (!references || references.length === 0) {
+    return null;
+  }
+
+  const lowerQuery = query.toLowerCase();
+
+  // Try to find a reference that matches keywords in the query
+  for (const ref of references) {
+    const refText = [ref.title, ref.description, ref.url].filter(Boolean).join(" ").toLowerCase();
+
+    // Simple keyword matching
+    const queryWords = lowerQuery.split(/\s+/).filter((w) => w.length > 2);
+    const matchScore = queryWords.filter((word) => refText.includes(word)).length;
+
+    if (matchScore >= 2 || (queryWords.length === 1 && matchScore === 1)) {
+      return ref;
+    }
+  }
+
+  return null;
+};

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -17,6 +17,7 @@ export {
   findReference,
   fetchReference,
   parseSuggestedFetch,
+  removeSuggestFetchMarkers,
 } from "./core/ai/command/query/interactive.js";
 
 // Utilities

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -7,14 +7,48 @@ export { listProfiles } from "./core/preprocessing/profiles.js";
 // AI API
 export { summarizeScript } from "./core/ai/command/summarize/index.js";
 export { queryScript } from "./core/ai/command/query/index.js";
-export { createInteractiveSession, sendInteractiveQuery, clearHistory, getHistory } from "./core/ai/command/query/interactive.js";
+export {
+  createInteractiveSession,
+  sendInteractiveQuery,
+  sendInteractiveQueryWithFetch,
+  clearHistory,
+  getHistory,
+  getReferences,
+  findReference,
+  fetchReference,
+  parseSuggestedFetch,
+} from "./core/ai/command/query/interactive.js";
+
+// Utilities
+export { fetchUrlContent } from "./core/ai/utils/fetcher.js";
+export type { FetchedContent } from "./core/ai/utils/fetcher.js";
 
 // Types
-export type { BeatVariant, BeatMeta, ExtendedBeat, ExtendedScript, OutputProfile, ProcessOptions, ProfileInfo } from "./types/index.js";
+export type {
+  BeatVariant,
+  BeatMeta,
+  ExtendedBeat,
+  ExtendedScript,
+  OutputProfile,
+  ProcessOptions,
+  ProfileInfo,
+  Reference,
+  FAQ,
+  ScriptMeta,
+} from "./types/index.js";
 export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat, ProviderConfig } from "./types/summarize.js";
 export type { QueryOptions, QueryResult, ConversationMessage, InteractiveQuerySession } from "./types/query.js";
 
 // Schemas (for validation)
-export { beatVariantSchema, beatMetaSchema, extendedBeatSchema, extendedScriptSchema, outputProfileSchema } from "./types/index.js";
+export {
+  beatVariantSchema,
+  beatMetaSchema,
+  extendedBeatSchema,
+  extendedScriptSchema,
+  outputProfileSchema,
+  referenceSchema,
+  faqSchema,
+  scriptMetaSchema,
+} from "./types/index.js";
 export { summarizeOptionsSchema, llmProviderSchema, summarizeFormatSchema } from "./types/summarize.js";
 export { queryOptionsSchema } from "./types/query.js";

--- a/packages/mulmocast-preprocessor/src/types/index.ts
+++ b/packages/mulmocast-preprocessor/src/types/index.ts
@@ -49,11 +49,61 @@ export const outputProfileSchema = z.object({
 export type OutputProfile = z.infer<typeof outputProfileSchema>;
 
 /**
+ * Reference - external resource reference
+ */
+export const referenceSchema = z.object({
+  type: z.enum(["web", "code", "document", "video"]).optional(),
+  url: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type Reference = z.infer<typeof referenceSchema>;
+
+/**
+ * FAQ - frequently asked question
+ */
+export const faqSchema = z.object({
+  question: z.string(),
+  answer: z.string(),
+  relatedBeats: z.array(z.string()).optional(),
+});
+
+export type FAQ = z.infer<typeof faqSchema>;
+
+/**
+ * Script Meta - script-level metadata for AI features
+ */
+export const scriptMetaSchema = z.object({
+  // Target audience and prerequisites
+  audience: z.string().optional(),
+  prerequisites: z.array(z.string()).optional(),
+
+  // Learning goals and background
+  goals: z.array(z.string()).optional(),
+  background: z.string().optional(),
+
+  // FAQ for quick Q&A matching
+  faq: z.array(faqSchema).optional(),
+
+  // Search and discovery
+  keywords: z.array(z.string()).optional(),
+  references: z.array(referenceSchema).optional(),
+
+  // Authoring info
+  author: z.string().optional(),
+  version: z.string().optional(),
+});
+
+export type ScriptMeta = z.infer<typeof scriptMetaSchema>;
+
+/**
  * Extended Script - script with variants, meta, and outputProfiles
  */
 export const extendedScriptSchema = mulmoScriptSchema.extend({
   beats: z.array(extendedBeatSchema),
   outputProfiles: z.record(z.string(), outputProfileSchema).optional(),
+  scriptMeta: scriptMetaSchema.optional(),
 });
 
 export type ExtendedScript = z.infer<typeof extendedScriptSchema>;

--- a/packages/mulmocast-preprocessor/src/types/query.ts
+++ b/packages/mulmocast-preprocessor/src/types/query.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { llmProviderSchema } from "./summarize.js";
+import type { FetchedContent } from "../core/ai/utils/fetcher.js";
 
 /**
  * Query Options - configuration for querying script content
@@ -51,4 +52,5 @@ export interface InteractiveQuerySession {
   scriptTitle: string;
   beatCount: number;
   history: ConversationMessage[];
+  fetchedContent?: FetchedContent;
 }


### PR DESCRIPTION
## Summary

- Add `scriptMeta` schema for script-level metadata
  - `audience`: Target audience description
  - `prerequisites`: Required knowledge/skills
  - `goals`: Learning goals
  - `background`: Background information about the content
  - `faq`: Frequently asked questions with answers
  - `keywords`: Script-level keywords for search
  - `references`: External resource references (URL, title, description, type)
  - `author`, `version`: Authoring information

- Add reference URL fetching for interactive query mode
  - `/refs` command to list available references
  - `/fetch <url>` command to fetch reference content
  - AI can suggest fetching references with `[SUGGEST_FETCH: <url>]`
  - Fetched content is included in subsequent queries for more detailed answers

- Update all 4 sample files with rich `scriptMeta` examples

## Test plan

- [x] `yarn format` passes
- [x] `yarn lint` passes (1 warning for cognitive complexity)
- [x] `yarn build` passes
- [x] `yarn test` passes (34 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)