### PR TITLE
feat: add @mulmocast/extended-types package

### DIFF
--- a/packages/mulmocast-extended-types/package.json
+++ b/packages/mulmocast-extended-types/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mulmocast/extended-types",
+  "version": "0.1.0",
+  "description": "Type definitions and Zod schemas for MulmoScript ExtendedScript format",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "./lib"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src",
+    "format": "prettier --write 'src/**/*.ts'",
+    "test": "node --import tsx --test test/*.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmocast-plus.git"
+  },
+  "author": "receptron",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/receptron/mulmocast-plus/issues"
+  },
+  "homepage": "https://github.com/receptron/mulmocast-plus#readme",
+  "dependencies": {
+    "mulmocast": "^2.1.35",
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/mulmocast-extended-types/src/index.ts
+++ b/packages/mulmocast-extended-types/src/index.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { mulmoBeatSchema, mulmoScriptSchema, mulmoImageAssetSchema } from "mulmocast";
+
+export type { MulmoImageAsset } from "mulmocast";
+
+/**
+ * Beat Variant - profile-specific content overrides
+ */
+export const beatVariantSchema = z.object({
+  text: z.string().optional(),
+  skip: z.boolean().optional(),
+  image: mulmoImageAssetSchema.optional(),
+  imagePrompt: z.string().optional(),
+});
+
+export type BeatVariant = z.infer<typeof beatVariantSchema>;
+
+/**
+ * Beat Meta - metadata for filtering and context
+ */
+export const beatMetaSchema = z.object({
+  tags: z.array(z.string()).optional(),
+  section: z.string().optional(),
+  context: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  expectedQuestions: z.array(z.string()).optional(),
+});
+
+export type BeatMeta = z.infer<typeof beatMetaSchema>;
+
+/**
+ * Extended Beat - beat with variants and meta fields
+ */
+export const extendedBeatSchema = mulmoBeatSchema.extend({
+  variants: z.record(z.string(), beatVariantSchema).optional(),
+  meta: beatMetaSchema.optional(),
+});
+
+export type ExtendedBeat = z.infer<typeof extendedBeatSchema>;
+
+/**
+ * Output Profile - profile display information
+ */
+export const outputProfileSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+export type OutputProfile = z.infer<typeof outputProfileSchema>;
+
+/**
+ * Reference - external resource reference
+ */
+export const referenceSchema = z.object({
+  type: z.enum(["web", "code", "document", "video"]).optional(),
+  url: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type Reference = z.infer<typeof referenceSchema>;
+
+/**
+ * FAQ - frequently asked question
+ */
+export const faqSchema = z.object({
+  question: z.string(),
+  answer: z.string(),
+  relatedBeats: z.array(z.string()).optional(),
+});
+
+export type FAQ = z.infer<typeof faqSchema>;
+
+/**
+ * Script Meta - script-level metadata for AI features
+ */
+export const scriptMetaSchema = z.object({
+  // Target audience and prerequisites
+  audience: z.string().optional(),
+  prerequisites: z.array(z.string()).optional(),
+
+  // Learning goals and background
+  goals: z.array(z.string()).optional(),
+  background: z.string().optional(),
+
+  // FAQ for quick Q&A matching
+  faq: z.array(faqSchema).optional(),
+
+  // Search and discovery
+  keywords: z.array(z.string()).optional(),
+  references: z.array(referenceSchema).optional(),
+
+  // Authoring info
+  author: z.string().optional(),
+  version: z.string().optional(),
+});
+
+export type ScriptMeta = z.infer<typeof scriptMetaSchema>;
+
+/**
+ * Extended Script - script with variants, meta, and outputProfiles
+ */
+export const extendedScriptSchema = mulmoScriptSchema.extend({
+  beats: z.array(extendedBeatSchema),
+  outputProfiles: z.record(z.string(), outputProfileSchema).optional(),
+  scriptMeta: scriptMetaSchema.optional(),
+});
+
+export type ExtendedScript = z.infer<typeof extendedScriptSchema>;

--- a/packages/mulmocast-extended-types/test/test_schema.ts
+++ b/packages/mulmocast-extended-types/test/test_schema.ts
@@ -1,0 +1,200 @@
+import test from "node:test";
+import assert from "node:assert";
+import {
+  beatVariantSchema,
+  beatMetaSchema,
+  extendedBeatSchema,
+  outputProfileSchema,
+  referenceSchema,
+  faqSchema,
+  scriptMetaSchema,
+  extendedScriptSchema,
+} from "../src/index.js";
+
+const minimalMulmoScript = {
+  $mulmocast: { version: "1.1" as const },
+  speechParams: { speakers: {} },
+  imageParams: { provider: "openai" as const, images: {} },
+  beats: [],
+};
+
+test("beatVariantSchema: valid variant", () => {
+  const result = beatVariantSchema.safeParse({
+    text: "override text",
+    skip: false,
+    imagePrompt: "a sunset",
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("beatVariantSchema: empty object is valid", () => {
+  const result = beatVariantSchema.safeParse({});
+  assert.strictEqual(result.success, true);
+});
+
+test("beatVariantSchema: rejects invalid skip type", () => {
+  const result = beatVariantSchema.safeParse({ skip: "yes" });
+  assert.strictEqual(result.success, false);
+});
+
+test("beatMetaSchema: valid meta with all fields", () => {
+  const result = beatMetaSchema.safeParse({
+    tags: ["intro", "overview"],
+    section: "opening",
+    context: "Background context",
+    keywords: ["api", "graphai"],
+    expectedQuestions: ["What is GraphAI?"],
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("beatMetaSchema: empty object is valid", () => {
+  const result = beatMetaSchema.safeParse({});
+  assert.strictEqual(result.success, true);
+});
+
+test("beatMetaSchema: rejects invalid tags type", () => {
+  const result = beatMetaSchema.safeParse({ tags: "not-an-array" });
+  assert.strictEqual(result.success, false);
+});
+
+test("outputProfileSchema: valid profile", () => {
+  const result = outputProfileSchema.safeParse({
+    name: "beginner",
+    description: "For beginners",
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("outputProfileSchema: rejects missing name", () => {
+  const result = outputProfileSchema.safeParse({ description: "no name" });
+  assert.strictEqual(result.success, false);
+});
+
+test("referenceSchema: valid reference with all fields", () => {
+  const result = referenceSchema.safeParse({
+    type: "web",
+    url: "https://example.com",
+    title: "Example",
+    description: "An example",
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("referenceSchema: minimal reference (url only)", () => {
+  const result = referenceSchema.safeParse({ url: "https://example.com" });
+  assert.strictEqual(result.success, true);
+});
+
+test("referenceSchema: rejects invalid type", () => {
+  const result = referenceSchema.safeParse({ url: "https://example.com", type: "invalid" });
+  assert.strictEqual(result.success, false);
+});
+
+test("referenceSchema: rejects missing url", () => {
+  const result = referenceSchema.safeParse({ type: "web" });
+  assert.strictEqual(result.success, false);
+});
+
+test("faqSchema: valid FAQ", () => {
+  const result = faqSchema.safeParse({
+    question: "What is this?",
+    answer: "A test",
+    relatedBeats: ["0", "1"],
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("faqSchema: rejects missing question", () => {
+  const result = faqSchema.safeParse({ answer: "no question" });
+  assert.strictEqual(result.success, false);
+});
+
+test("scriptMetaSchema: valid full meta", () => {
+  const result = scriptMetaSchema.safeParse({
+    audience: "developers",
+    prerequisites: ["TypeScript basics"],
+    goals: ["Understand ExtendedScript"],
+    background: "Background info",
+    faq: [{ question: "Q?", answer: "A" }],
+    keywords: ["mulmocast"],
+    references: [{ url: "https://example.com", type: "web" }],
+    author: "test",
+    version: "1.0",
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("scriptMetaSchema: empty object is valid", () => {
+  const result = scriptMetaSchema.safeParse({});
+  assert.strictEqual(result.success, true);
+});
+
+test("extendedBeatSchema: valid beat with meta", () => {
+  const result = extendedBeatSchema.safeParse({
+    text: "Hello world",
+    meta: {
+      tags: ["intro"],
+      section: "opening",
+      context: "Opening slide",
+    },
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("extendedBeatSchema: valid beat with variants", () => {
+  const result = extendedBeatSchema.safeParse({
+    text: "Hello world",
+    variants: {
+      beginner: { text: "Simple hello" },
+      advanced: { skip: true },
+    },
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("extendedScriptSchema: valid minimal ExtendedScript", () => {
+  const result = extendedScriptSchema.safeParse({
+    ...minimalMulmoScript,
+    beats: [{ text: "slide 1" }],
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("extendedScriptSchema: valid full ExtendedScript", () => {
+  const result = extendedScriptSchema.safeParse({
+    ...minimalMulmoScript,
+    beats: [
+      {
+        text: "slide 1",
+        meta: { tags: ["intro"], section: "opening", context: "First slide" },
+        variants: { beginner: { text: "Easy version" } },
+      },
+    ],
+    outputProfiles: {
+      beginner: { name: "beginner", description: "For beginners" },
+    },
+    scriptMeta: {
+      audience: "developers",
+      goals: ["Learn the basics"],
+      keywords: ["test"],
+    },
+  });
+  assert.strictEqual(result.success, true);
+});
+
+test("extendedScriptSchema: rejects missing $mulmocast", () => {
+  const result = extendedScriptSchema.safeParse({
+    beats: [{ text: "slide 1" }],
+  });
+  assert.strictEqual(result.success, false);
+});
+
+test("extendedScriptSchema: rejects invalid scriptMeta", () => {
+  const result = extendedScriptSchema.safeParse({
+    ...minimalMulmoScript,
+    beats: [{ text: "slide 1" }],
+    scriptMeta: { audience: 123 },
+  });
+  assert.strictEqual(result.success, false);
+});

--- a/packages/mulmocast-extended-types/tsconfig.json
+++ b/packages/mulmocast-extended-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "include": ["src"]
+}

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
+    "@mulmocast/extended-types": "0.1.0",
     "@graphai/anthropic_agent": "^2.0.12",
     "@graphai/gemini_agent": "^2.0.5",
     "@graphai/groq_agent": "^2.0.2",

--- a/packages/mulmocast-preprocessor/src/types/index.ts
+++ b/packages/mulmocast-preprocessor/src/types/index.ts
@@ -1,112 +1,23 @@
-import { z } from "zod";
-import { mulmoBeatSchema, mulmoScriptSchema, mulmoImageAssetSchema } from "mulmocast";
-
-export type { MulmoImageAsset } from "mulmocast";
-
-/**
- * Beat Variant - profile-specific content overrides
- */
-export const beatVariantSchema = z.object({
-  text: z.string().optional(),
-  skip: z.boolean().optional(),
-  image: mulmoImageAssetSchema.optional(),
-  imagePrompt: z.string().optional(),
-});
-
-export type BeatVariant = z.infer<typeof beatVariantSchema>;
-
-/**
- * Beat Meta - metadata for filtering and context
- */
-export const beatMetaSchema = z.object({
-  tags: z.array(z.string()).optional(),
-  section: z.string().optional(),
-  context: z.string().optional(),
-  keywords: z.array(z.string()).optional(),
-  expectedQuestions: z.array(z.string()).optional(),
-});
-
-export type BeatMeta = z.infer<typeof beatMetaSchema>;
-
-/**
- * Extended Beat - beat with variants and meta fields
- */
-export const extendedBeatSchema = mulmoBeatSchema.extend({
-  variants: z.record(z.string(), beatVariantSchema).optional(),
-  meta: beatMetaSchema.optional(),
-});
-
-export type ExtendedBeat = z.infer<typeof extendedBeatSchema>;
-
-/**
- * Output Profile - profile display information
- */
-export const outputProfileSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
-
-export type OutputProfile = z.infer<typeof outputProfileSchema>;
-
-/**
- * Reference - external resource reference
- */
-export const referenceSchema = z.object({
-  type: z.enum(["web", "code", "document", "video"]).optional(),
-  url: z.string(),
-  title: z.string().optional(),
-  description: z.string().optional(),
-});
-
-export type Reference = z.infer<typeof referenceSchema>;
-
-/**
- * FAQ - frequently asked question
- */
-export const faqSchema = z.object({
-  question: z.string(),
-  answer: z.string(),
-  relatedBeats: z.array(z.string()).optional(),
-});
-
-export type FAQ = z.infer<typeof faqSchema>;
-
-/**
- * Script Meta - script-level metadata for AI features
- */
-export const scriptMetaSchema = z.object({
-  // Target audience and prerequisites
-  audience: z.string().optional(),
-  prerequisites: z.array(z.string()).optional(),
-
-  // Learning goals and background
-  goals: z.array(z.string()).optional(),
-  background: z.string().optional(),
-
-  // FAQ for quick Q&A matching
-  faq: z.array(faqSchema).optional(),
-
-  // Search and discovery
-  keywords: z.array(z.string()).optional(),
-  references: z.array(referenceSchema).optional(),
-
-  // Authoring info
-  author: z.string().optional(),
-  version: z.string().optional(),
-});
-
-export type ScriptMeta = z.infer<typeof scriptMetaSchema>;
-
-/**
- * Extended Script - script with variants, meta, and outputProfiles
- */
-export const extendedScriptSchema = mulmoScriptSchema.extend({
-  beats: z.array(extendedBeatSchema),
-  outputProfiles: z.record(z.string(), outputProfileSchema).optional(),
-  scriptMeta: scriptMetaSchema.optional(),
-});
-
-export type ExtendedScript = z.infer<typeof extendedScriptSchema>;
+// Re-export from @mulmocast/extended-types
+export {
+  beatVariantSchema,
+  type BeatVariant,
+  beatMetaSchema,
+  type BeatMeta,
+  extendedBeatSchema,
+  type ExtendedBeat,
+  outputProfileSchema,
+  type OutputProfile,
+  referenceSchema,
+  type Reference,
+  faqSchema,
+  type FAQ,
+  scriptMetaSchema,
+  type ScriptMeta,
+  extendedScriptSchema,
+  type ExtendedScript,
+  type MulmoImageAsset,
+} from "@mulmocast/extended-types";
 
 /**
  * Process Options - options for processScript

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,7 +512,7 @@
   resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
   integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
 
-"@isaacs/brace-expansion@^5.0.0", "@isaacs/brace-expansion@^5.0.1":
+"@isaacs/brace-expansion@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
   integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==


### PR DESCRIPTION
## Summary

- Extract ExtendedScript type definitions and Zod schemas from `mulmocast-preprocessor` into a new lightweight package `@mulmocast/extended-types`
- Update `mulmocast-preprocessor` to re-export types from the new package
- Add 22 schema validation tests for the new package

## Motivation

`mulmocast-preprocessor` has heavy dependencies (GraphAI, LLM agents). Downstream projects like MulmoCast-Slides need only the type definitions and Zod schemas for validation, not the full preprocessor. This separation enables lightweight type-only consumption.

## Test plan

- [ ] `yarn build` succeeds for all packages
- [ ] `@mulmocast/extended-types`: 22 schema tests pass
- [ ] `mulmocast-preprocessor`: 34 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)