### PR TITLE
refactor: remove types/index.ts re-exports

### DIFF
--- a/packages/mulmocast-extended-types/package.json
+++ b/packages/mulmocast-extended-types/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
-    "mulmocast": "^2.1.35",
+    "@mulmocast/types": "^2.1.35",
     "zod": "^4.3.6"
   }
 }

--- a/packages/mulmocast-extended-types/src/index.ts
+++ b/packages/mulmocast-extended-types/src/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { mulmoBeatSchema, mulmoScriptSchema, mulmoImageAssetSchema } from "mulmocast";
+import { mulmoBeatSchema, mulmoScriptSchema, mulmoImageAssetSchema } from "@mulmocast/types";
 
-export type { MulmoImageAsset } from "mulmocast";
+export type { MulmoImageAsset } from "@mulmocast/types";
 
 /**
  * Beat Variant - profile-specific content overrides

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -42,7 +42,7 @@
     "@graphai/vanilla": "^2.0.12",
     "dotenv": "^17.2.4",
     "graphai": "^2.0.16",
-    "mulmocast": "^2.1.35",
+    "@mulmocast/types": "^2.1.35",
     "yargs": "^18.0.0",
     "zod": "^4.3.6"
   },

--- a/packages/mulmocast-preprocessor/src/cli/commands/process.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/process.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "fs";
 import { GraphAILogger } from "graphai";
 import { processScript } from "../../core/preprocessing/process.js";
-import type { ExtendedScript } from "../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 
 interface ProcessOptions {
   profile?: string;

--- a/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { GraphAILogger } from "graphai";
 import { listProfiles } from "../../core/preprocessing/profiles.js";
-import type { ExtendedScript } from "../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 
 /**
  * List available profiles in script

--- a/packages/mulmocast-preprocessor/src/cli/commands/query.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/query.ts
@@ -13,7 +13,7 @@ import {
 } from "../../core/ai/command/query/interactive.js";
 import { loadScript } from "../utils.js";
 import type { LLMProvider } from "../../types/summarize.js";
-import type { Reference } from "../../types/index.js";
+import type { Reference } from "@mulmocast/extended-types";
 
 interface QueryCommandOptions {
   provider?: LLMProvider;

--- a/packages/mulmocast-preprocessor/src/cli/utils.ts
+++ b/packages/mulmocast-preprocessor/src/cli/utils.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import type { ExtendedScript } from "../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 
 /**
  * Check if input is a URL

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/index.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/index.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript } from "../../../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 import type { QueryOptions, QueryResult } from "../../../../types/query.js";
 import { queryOptionsSchema } from "../../../../types/query.js";
 import { executeLLM, filterScript } from "../../llm.js";

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript, Reference } from "../../../../types/index.js";
+import type { ExtendedScript, Reference } from "@mulmocast/extended-types";
 import type { QueryOptions, InteractiveQuerySession, ConversationMessage } from "../../../../types/query.js";
 import { queryOptionsSchema } from "../../../../types/query.js";
 import { executeLLM, filterScript, getLanguageName } from "../../llm.js";

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -1,5 +1,5 @@
 import type { QueryOptions, ConversationMessage } from "../../../../types/query.js";
-import type { ExtendedScript } from "../../../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/index.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/index.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript } from "../../../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 import type { SummarizeOptions, SummarizeResult } from "../../../../types/summarize.js";
 import { summarizeOptionsSchema } from "../../../../types/summarize.js";
 import { executeLLM, filterScript } from "../../llm.js";

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
@@ -1,5 +1,5 @@
 import type { SummarizeOptions } from "../../../../types/summarize.js";
-import type { ExtendedScript } from "../../../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**

--- a/packages/mulmocast-preprocessor/src/core/ai/llm.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/llm.ts
@@ -7,7 +7,7 @@ import { anthropicAgent } from "@graphai/anthropic_agent";
 import { groqAgent } from "@graphai/groq_agent";
 import { geminiAgent } from "@graphai/gemini_agent";
 
-import type { ExtendedScript } from "../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
 import type { LLMProvider } from "../../types/summarize.js";
 import { filterBySection, filterByTags } from "../preprocessing/filter.js";
 

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
@@ -1,4 +1,4 @@
-import type { MulmoScript, MulmoBeat } from "mulmocast";
+import type { MulmoScript, MulmoBeat } from "@mulmocast/types";
 import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
 
 const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
@@ -1,5 +1,5 @@
 import type { MulmoScript, MulmoBeat } from "mulmocast";
-import type { ExtendedScript, ExtendedBeat } from "../../types/index.js";
+import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
 
 const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
   const { variants: __variants, meta: __meta, ...baseBeat } = beat;

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
@@ -1,5 +1,6 @@
 import type { MulmoScript } from "mulmocast";
-import type { ExtendedScript, ProcessOptions } from "../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ProcessOptions } from "../../types/index.js";
 import { applyProfile } from "./variant.js";
 import { filterBySection, filterByTags, stripExtendedFields } from "./filter.js";
 

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
@@ -1,4 +1,4 @@
-import type { MulmoScript } from "mulmocast";
+import type { MulmoScript } from "@mulmocast/types";
 import type { ExtendedScript } from "@mulmocast/extended-types";
 import type { ProcessOptions } from "../../types/index.js";
 import { applyProfile } from "./variant.js";

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/profiles.ts
@@ -1,4 +1,5 @@
-import type { ExtendedScript, ProfileInfo } from "../../types/index.js";
+import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ProfileInfo } from "../../types/index.js";
 
 /**
  * Get list of available profiles from script

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
@@ -1,4 +1,4 @@
-import type { MulmoScript, MulmoBeat } from "mulmocast";
+import type { MulmoScript, MulmoBeat } from "@mulmocast/types";
 import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
 
 /**

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
@@ -1,5 +1,5 @@
 import type { MulmoScript, MulmoBeat } from "mulmocast";
-import type { ExtendedScript, ExtendedBeat } from "../../types/index.js";
+import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
 
 /**
  * Apply profile variant to a single beat

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -24,23 +24,18 @@ export {
 export { fetchUrlContent } from "./core/ai/utils/fetcher.js";
 export type { FetchedContent } from "./core/ai/utils/fetcher.js";
 
-// Types
+// Types (from @mulmocast/extended-types)
 export type {
   BeatVariant,
   BeatMeta,
   ExtendedBeat,
   ExtendedScript,
   OutputProfile,
-  ProcessOptions,
-  ProfileInfo,
   Reference,
   FAQ,
   ScriptMeta,
-} from "./types/index.js";
-export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat, ProviderConfig } from "./types/summarize.js";
-export type { QueryOptions, QueryResult, ConversationMessage, InteractiveQuerySession } from "./types/query.js";
-
-// Schemas (for validation)
+  MulmoImageAsset,
+} from "@mulmocast/extended-types";
 export {
   beatVariantSchema,
   beatMetaSchema,
@@ -50,6 +45,13 @@ export {
   referenceSchema,
   faqSchema,
   scriptMetaSchema,
-} from "./types/index.js";
+} from "@mulmocast/extended-types";
+
+// Types (local)
+export type { ProcessOptions, ProfileInfo } from "./types/index.js";
+export type { SummarizeOptions, SummarizeResult, LLMProvider, SummarizeFormat, ProviderConfig } from "./types/summarize.js";
+export type { QueryOptions, QueryResult, ConversationMessage, InteractiveQuerySession } from "./types/query.js";
+
+// Schemas (local)
 export { summarizeOptionsSchema, llmProviderSchema, summarizeFormatSchema } from "./types/summarize.js";
 export { queryOptionsSchema } from "./types/query.js";

--- a/packages/mulmocast-preprocessor/src/types/index.ts
+++ b/packages/mulmocast-preprocessor/src/types/index.ts
@@ -1,24 +1,3 @@
-// Re-export from @mulmocast/extended-types
-export {
-  beatVariantSchema,
-  type BeatVariant,
-  beatMetaSchema,
-  type BeatMeta,
-  extendedBeatSchema,
-  type ExtendedBeat,
-  outputProfileSchema,
-  type OutputProfile,
-  referenceSchema,
-  type Reference,
-  faqSchema,
-  type FAQ,
-  scriptMetaSchema,
-  type ScriptMeta,
-  extendedScriptSchema,
-  type ExtendedScript,
-  type MulmoImageAsset,
-} from "@mulmocast/extended-types";
-
 /**
  * Process Options - options for processScript
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,13 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
+"@mulmocast/types@^2.1.35":
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.35.tgz#63c961deb27090a1861c153200b5e2fe8042c68d"
+  integrity sha512-L78IvYCgZzjdbkzTazCO2FoDcYAkv+bVJ+29MG4gRAh2wTkPhHMDBX3UgNau0xsqN+1ClYw8sAqOp4Adhmnhfg==
+  dependencies:
+    zod "^4.3.5"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -4221,7 +4228,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4.0", zod@^4.3.6:
+"zod@^3.25 || ^4.0", zod@^4.3.5, zod@^4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## Summary

- Remove re-exports of `@mulmocast/extended-types` from `types/index.ts`
- All 13 internal files now import directly from `@mulmocast/extended-types`
- `types/index.ts` retains only local types (`ProcessOptions`, `ProfileInfo`)
- `src/index.ts` exports extended-types directly for package consumers

## Test plan

- [x] `yarn format` passes
- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)