### PR TITLE
feat: add notes field to BeatMeta schema

### DIFF
--- a/packages/mulmocast-extended-types/package.json
+++ b/packages/mulmocast-extended-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/extended-types",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Type definitions and Zod schemas for MulmoScript ExtendedScript format",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/mulmocast-extended-types/src/index.ts
+++ b/packages/mulmocast-extended-types/src/index.ts
@@ -22,6 +22,7 @@ export const beatMetaSchema = z.object({
   tags: z.array(z.string()).optional(),
   section: z.string().optional(),
   context: z.string().optional(),
+  notes: z.string().optional(),
   keywords: z.array(z.string()).optional(),
   expectedQuestions: z.array(z.string()).optional(),
 });

--- a/packages/mulmocast-extended-types/test/test_schema.ts
+++ b/packages/mulmocast-extended-types/test/test_schema.ts
@@ -42,6 +42,7 @@ test("beatMetaSchema: valid meta with all fields", () => {
     tags: ["intro", "overview"],
     section: "opening",
     context: "Background context",
+    notes: "Raw extracted text from source document",
     keywords: ["api", "graphai"],
     expectedQuestions: ["What is GraphAI?"],
   });


### PR DESCRIPTION
## Summary
- Add optional `notes` string field to `beatMetaSchema` in `@mulmocast/extended-types`
- Used to store raw extracted text from source documents (e.g., PDF text extraction)
- Version bump to 0.2.0

## Test plan
- [x] All 22 existing tests pass
- [x] `notes` field included in "valid meta with all fields" test

🤖 Generated with [Claude Code](https://claude.com/claude-code)