### PR TITLE
fix: strip scriptMeta when converting ExtendedScript to MulmoScript

### DIFF
--- a/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
@@ -7,7 +7,7 @@ const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
 };
 
 const filterBeatsToMulmoScript = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): MulmoScript => {
-  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+  const { outputProfiles: __outputProfiles, scriptMeta: __scriptMeta, ...baseScript } = script;
   return {
     ...baseScript,
     beats: script.beats.filter(predicate).map(stripBeatExtendedFields),

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
@@ -26,7 +26,7 @@ const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat 
  * Apply profile to script and return standard MulmoScript
  */
 export const applyProfile = (script: ExtendedScript, profileName: string): MulmoScript => {
-  const { outputProfiles: __outputProfiles, ...baseScript } = script;
+  const { outputProfiles: __outputProfiles, scriptMeta: __scriptMeta, ...baseScript } = script;
 
   return {
     ...baseScript,


### PR DESCRIPTION
## Summary
- Fix `stripExtendedFields` and `applyProfile` not removing `scriptMeta` from output
- Add schema validation tests using `mulmoScriptSchema.parse()` to prevent regression
- Add full `scriptMeta` and beat `meta` fields to test fixture

## Test plan
- [x] All 39 tests pass (`yarn test`)
- [x] `mulmoScriptSchema.parse()` validates output of `stripExtendedFields`, `applyProfile`, and `processScript`
- [x] Build, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)