### PR TITLE
refactor: rename ExtendedScript to ExtendedMulmoScript

### DIFF
--- a/packages/mulmocast-extended-types/package.json
+++ b/packages/mulmocast-extended-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmocast/extended-types",
-  "version": "0.2.0",
-  "description": "Type definitions and Zod schemas for MulmoScript ExtendedScript format",
+  "version": "0.3.0",
+  "description": "Type definitions and Zod schemas for MulmoScript ExtendedMulmoScript format",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/mulmocast-extended-types/src/index.ts
+++ b/packages/mulmocast-extended-types/src/index.ts
@@ -32,12 +32,12 @@ export type BeatMeta = z.infer<typeof beatMetaSchema>;
 /**
  * Extended Beat - beat with variants and meta fields
  */
-export const extendedBeatSchema = mulmoBeatSchema.extend({
+export const extendedMulmoBeatSchema = mulmoBeatSchema.extend({
   variants: z.record(z.string(), beatVariantSchema).optional(),
   meta: beatMetaSchema.optional(),
 });
 
-export type ExtendedBeat = z.infer<typeof extendedBeatSchema>;
+export type ExtendedMulmoBeat = z.infer<typeof extendedMulmoBeatSchema>;
 
 /**
  * Output Profile - profile display information
@@ -101,10 +101,10 @@ export type ScriptMeta = z.infer<typeof scriptMetaSchema>;
 /**
  * Extended Script - script with variants, meta, and outputProfiles
  */
-export const extendedScriptSchema = mulmoScriptSchema.extend({
-  beats: z.array(extendedBeatSchema),
+export const extendedMulmoScriptSchema = mulmoScriptSchema.extend({
+  beats: z.array(extendedMulmoBeatSchema),
   outputProfiles: z.record(z.string(), outputProfileSchema).optional(),
   scriptMeta: scriptMetaSchema.optional(),
 });
 
-export type ExtendedScript = z.infer<typeof extendedScriptSchema>;
+export type ExtendedMulmoScript = z.infer<typeof extendedMulmoScriptSchema>;

--- a/packages/mulmocast-extended-types/test/test_schema.ts
+++ b/packages/mulmocast-extended-types/test/test_schema.ts
@@ -3,12 +3,12 @@ import assert from "node:assert";
 import {
   beatVariantSchema,
   beatMetaSchema,
-  extendedBeatSchema,
+  extendedMulmoBeatSchema,
   outputProfileSchema,
   referenceSchema,
   faqSchema,
   scriptMetaSchema,
-  extendedScriptSchema,
+  extendedMulmoScriptSchema,
 } from "../src/index.js";
 
 const minimalMulmoScript = {
@@ -115,7 +115,7 @@ test("scriptMetaSchema: valid full meta", () => {
   const result = scriptMetaSchema.safeParse({
     audience: "developers",
     prerequisites: ["TypeScript basics"],
-    goals: ["Understand ExtendedScript"],
+    goals: ["Understand ExtendedMulmoScript"],
     background: "Background info",
     faq: [{ question: "Q?", answer: "A" }],
     keywords: ["mulmocast"],
@@ -131,8 +131,8 @@ test("scriptMetaSchema: empty object is valid", () => {
   assert.strictEqual(result.success, true);
 });
 
-test("extendedBeatSchema: valid beat with meta", () => {
-  const result = extendedBeatSchema.safeParse({
+test("extendedMulmoBeatSchema: valid beat with meta", () => {
+  const result = extendedMulmoBeatSchema.safeParse({
     text: "Hello world",
     meta: {
       tags: ["intro"],
@@ -143,8 +143,8 @@ test("extendedBeatSchema: valid beat with meta", () => {
   assert.strictEqual(result.success, true);
 });
 
-test("extendedBeatSchema: valid beat with variants", () => {
-  const result = extendedBeatSchema.safeParse({
+test("extendedMulmoBeatSchema: valid beat with variants", () => {
+  const result = extendedMulmoBeatSchema.safeParse({
     text: "Hello world",
     variants: {
       beginner: { text: "Simple hello" },
@@ -154,16 +154,16 @@ test("extendedBeatSchema: valid beat with variants", () => {
   assert.strictEqual(result.success, true);
 });
 
-test("extendedScriptSchema: valid minimal ExtendedScript", () => {
-  const result = extendedScriptSchema.safeParse({
+test("extendedMulmoScriptSchema: valid minimal ExtendedMulmoScript", () => {
+  const result = extendedMulmoScriptSchema.safeParse({
     ...minimalMulmoScript,
     beats: [{ text: "slide 1" }],
   });
   assert.strictEqual(result.success, true);
 });
 
-test("extendedScriptSchema: valid full ExtendedScript", () => {
-  const result = extendedScriptSchema.safeParse({
+test("extendedMulmoScriptSchema: valid full ExtendedMulmoScript", () => {
+  const result = extendedMulmoScriptSchema.safeParse({
     ...minimalMulmoScript,
     beats: [
       {
@@ -184,15 +184,15 @@ test("extendedScriptSchema: valid full ExtendedScript", () => {
   assert.strictEqual(result.success, true);
 });
 
-test("extendedScriptSchema: rejects missing $mulmocast", () => {
-  const result = extendedScriptSchema.safeParse({
+test("extendedMulmoScriptSchema: rejects missing $mulmocast", () => {
+  const result = extendedMulmoScriptSchema.safeParse({
     beats: [{ text: "slide 1" }],
   });
   assert.strictEqual(result.success, false);
 });
 
-test("extendedScriptSchema: rejects invalid scriptMeta", () => {
-  const result = extendedScriptSchema.safeParse({
+test("extendedMulmoScriptSchema: rejects invalid scriptMeta", () => {
+  const result = extendedMulmoScriptSchema.safeParse({
     ...minimalMulmoScript,
     beats: [{ text: "slide 1" }],
     scriptMeta: { audience: 123 },

--- a/packages/mulmocast-preprocessor/README.md
+++ b/packages/mulmocast-preprocessor/README.md
@@ -106,9 +106,9 @@ mulmocast-preprocessor query script.json  # Omit question for interactive mode
 
 ```typescript
 import { processScript, listProfiles, applyProfile } from "mulmocast-preprocessor";
-import type { ExtendedScript } from "mulmocast-preprocessor";
+import type { ExtendedMulmoScript } from "mulmocast-preprocessor";
 
-const script: ExtendedScript = {
+const script: ExtendedMulmoScript = {
   title: "My Presentation",
   beats: [
     {
@@ -148,7 +148,7 @@ const result = processScript(script, {
 Main processing function that applies profile and filters.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script with variants/meta
+- `script: ExtendedMulmoScript` - Input script with variants/meta
 - `options: ProcessOptions` - Processing options
   - `profile?: string` - Profile name to apply
   - `section?: string` - Filter by section
@@ -161,7 +161,7 @@ Main processing function that applies profile and filters.
 Apply a profile to the script, replacing text/image and skipping marked beats.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script
+- `script: ExtendedMulmoScript` - Input script
 - `profileName: string` - Profile name
 
 **Returns:** `MulmoScript` - Processed script
@@ -171,7 +171,7 @@ Apply a profile to the script, replacing text/image and skipping marked beats.
 Get list of available profiles from script.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script
+- `script: ExtendedMulmoScript` - Input script
 
 **Returns:** `ProfileInfo[]` - Array of profile info with beat counts
 
@@ -188,7 +188,7 @@ Filter beats by tags (extracts beats that have any of the specified tags).
 Generate a summary of the script content using LLM.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script
+- `script: ExtendedMulmoScript` - Input script
 - `options: SummarizeOptions` - Summarization options
   - `provider?: LLMProvider` - LLM provider (default: "openai")
   - `model?: string` - Model name
@@ -204,7 +204,7 @@ Generate a summary of the script content using LLM.
 Ask a question about the script content.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script
+- `script: ExtendedMulmoScript` - Input script
 - `question: string` - Question to ask
 - `options: QueryOptions` - Query options (same as summarize)
 
@@ -215,7 +215,7 @@ Ask a question about the script content.
 Create an interactive query session for follow-up questions.
 
 **Parameters:**
-- `script: ExtendedScript` - Input script
+- `script: ExtendedMulmoScript` - Input script
 - `options: QueryOptions` - Query options
 
 **Returns:** Session object with `sendInteractiveQuery()` method
@@ -233,10 +233,10 @@ For AI features (summarize, query), set the API key for your LLM provider:
 
 ## Extended Schema
 
-### ExtendedBeat
+### ExtendedMulmoBeat
 
 ```typescript
-interface ExtendedBeat extends MulmoBeat {
+interface ExtendedMulmoBeat extends MulmoBeat {
   variants?: Record<string, BeatVariant>;
   meta?: BeatMeta;
 }

--- a/packages/mulmocast-preprocessor/docs/specification.md
+++ b/packages/mulmocast-preprocessor/docs/specification.md
@@ -100,10 +100,10 @@ The schema is fully documented and can be implemented by any tool:
 
 ```typescript
 // The schema is defined using Zod and exported from the package
-import { extendedScriptSchema, extendedBeatSchema, beatMetaSchema } from "mulmocast-preprocessor";
+import { extendedMulmoScriptSchema, extendedMulmoBeatSchema, beatMetaSchema } from "mulmocast-preprocessor";
 
 // Validate your own Extended MulmoScript
-const result = extendedScriptSchema.safeParse(yourScript);
+const result = extendedMulmoScriptSchema.safeParse(yourScript);
 ```
 
 ### General-Purpose AI (Claude Code, etc.)
@@ -170,8 +170,8 @@ The type definitions serve as the authoritative schema:
 
 | Type | Purpose |
 |------|---------|
-| `ExtendedScript` | Root document with beats, variants, and profiles |
-| `ExtendedBeat` | Beat with optional `variants` and `meta` |
+| `ExtendedMulmoScript` | Root document with beats, variants, and profiles |
+| `ExtendedMulmoBeat` | Beat with optional `variants` and `meta` |
 | `BeatVariant` | Profile-specific overrides (`text`, `skip`, `image`) |
 | `BeatMeta` | Metadata for filtering and AI features |
 | `OutputProfile` | Profile display information |

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -39,7 +39,7 @@
     "@graphai/groq_agent": "^2.0.2",
     "@graphai/openai_agent": "^2.0.9",
     "@graphai/vanilla": "^2.0.12",
-    "@mulmocast/extended-types": "^0.1.0",
+    "@mulmocast/extended-types": "^0.3.0",
     "@mulmocast/types": "^2.1.35",
     "dotenv": "^17.2.4",
     "graphai": "^2.0.16",

--- a/packages/mulmocast-preprocessor/src/cli/commands/process.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/process.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "fs";
 import { GraphAILogger } from "graphai";
 import { processScript } from "../../core/preprocessing/process.js";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 
 interface ProcessOptions {
   profile?: string;
@@ -16,7 +16,7 @@ interface ProcessOptions {
 export const processCommand = (scriptPath: string, options: ProcessOptions): void => {
   try {
     const content = readFileSync(scriptPath, "utf-8");
-    const script: ExtendedScript = JSON.parse(content);
+    const script: ExtendedMulmoScript = JSON.parse(content);
 
     const result = processScript(script, {
       profile: options.profile,

--- a/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/cli/commands/profiles.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { GraphAILogger } from "graphai";
 import { listProfiles } from "../../core/preprocessing/profiles.js";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 
 /**
  * List available profiles in script
@@ -9,7 +9,7 @@ import type { ExtendedScript } from "@mulmocast/extended-types";
 export const profilesCommand = (scriptPath: string): void => {
   try {
     const content = readFileSync(scriptPath, "utf-8");
-    const script: ExtendedScript = JSON.parse(content);
+    const script: ExtendedMulmoScript = JSON.parse(content);
 
     const profiles = listProfiles(script);
 

--- a/packages/mulmocast-preprocessor/src/cli/utils.ts
+++ b/packages/mulmocast-preprocessor/src/cli/utils.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 
 /**
  * Check if input is a URL
@@ -11,7 +11,7 @@ export const isUrl = (input: string): boolean => {
 /**
  * Fetch JSON from URL with timeout
  */
-const fetchJson = async (url: string): Promise<ExtendedScript> => {
+const fetchJson = async (url: string): Promise<ExtendedMulmoScript> => {
   const controller = new AbortController();
   const timeout_ms = 30000;
   const timeoutId = setTimeout(() => controller.abort(), timeout_ms);
@@ -21,7 +21,7 @@ const fetchJson = async (url: string): Promise<ExtendedScript> => {
     if (!response.ok) {
       throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
     }
-    return (await response.json()) as ExtendedScript;
+    return (await response.json()) as ExtendedMulmoScript;
   } finally {
     clearTimeout(timeoutId);
   }
@@ -30,10 +30,10 @@ const fetchJson = async (url: string): Promise<ExtendedScript> => {
 /**
  * Load script from file path or URL
  */
-export const loadScript = async (input: string): Promise<ExtendedScript> => {
+export const loadScript = async (input: string): Promise<ExtendedMulmoScript> => {
   if (isUrl(input)) {
     return fetchJson(input);
   }
   const content = readFileSync(input, "utf-8");
-  return JSON.parse(content) as ExtendedScript;
+  return JSON.parse(content) as ExtendedMulmoScript;
 };

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/index.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/index.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { QueryOptions, QueryResult } from "../../../../types/query.js";
 import { queryOptionsSchema } from "../../../../types/query.js";
 import { executeLLM, filterScript } from "../../llm.js";
@@ -7,7 +7,7 @@ import { buildUserPrompt, getSystemPrompt } from "./prompts.js";
 /**
  * Main query function - answers a question based on script content
  */
-export const queryScript = async (script: ExtendedScript, question: string, options: Partial<QueryOptions> = {}): Promise<QueryResult> => {
+export const queryScript = async (script: ExtendedMulmoScript, question: string, options: Partial<QueryOptions> = {}): Promise<QueryResult> => {
   // Validate and apply defaults
   const validatedOptions = queryOptionsSchema.parse(options);
 

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/interactive.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript, Reference } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript, Reference } from "@mulmocast/extended-types";
 import type { QueryOptions, InteractiveQuerySession, ConversationMessage } from "../../../../types/query.js";
 import { queryOptionsSchema } from "../../../../types/query.js";
 import { executeLLM, filterScript, getLanguageName } from "../../llm.js";
@@ -9,9 +9,9 @@ import { fetchUrlContent, findMatchingReference, type FetchedContent } from "../
  * Create an interactive query session
  */
 export const createInteractiveSession = (
-  script: ExtendedScript,
+  script: ExtendedMulmoScript,
   options: Partial<QueryOptions> = {},
-): { session: InteractiveQuerySession; filteredScript: ExtendedScript; validatedOptions: QueryOptions } => {
+): { session: InteractiveQuerySession; filteredScript: ExtendedMulmoScript; validatedOptions: QueryOptions } => {
   const validatedOptions = queryOptionsSchema.parse(options);
   const filteredScript = filterScript(script, validatedOptions);
   const scriptTitle = script.title || "Untitled";
@@ -29,7 +29,7 @@ export const createInteractiveSession = (
  * Send a question in an interactive session
  */
 export const sendInteractiveQuery = async (
-  filteredScript: ExtendedScript,
+  filteredScript: ExtendedMulmoScript,
   question: string,
   session: InteractiveQuerySession,
   options: QueryOptions,
@@ -88,7 +88,7 @@ export const removeSuggestFetchMarkers = (response: string): string => {
 /**
  * Get available references from script
  */
-export const getReferences = (script: ExtendedScript): Reference[] => {
+export const getReferences = (script: ExtendedMulmoScript): Reference[] => {
   return script.scriptMeta?.references || [];
 };
 
@@ -102,7 +102,7 @@ export const fetchReference = async (url: string, verbose = false): Promise<Fetc
 /**
  * Find matching reference for a query
  */
-export const findReference = (script: ExtendedScript, query: string): Reference | null => {
+export const findReference = (script: ExtendedMulmoScript, query: string): Reference | null => {
   const references = getReferences(script);
   return findMatchingReference(references, query);
 };
@@ -111,7 +111,7 @@ export const findReference = (script: ExtendedScript, query: string): Reference 
  * Send a question with fetched reference content
  */
 export const sendInteractiveQueryWithFetch = async (
-  filteredScript: ExtendedScript,
+  filteredScript: ExtendedMulmoScript,
   question: string,
   fetchedContent: FetchedContent,
   session: InteractiveQuerySession,

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -1,5 +1,5 @@
 import type { QueryOptions, ConversationMessage } from "../../../../types/query.js";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**
@@ -33,7 +33,7 @@ export const getSystemPrompt = (options: QueryOptions): string => {
 /**
  * Build user prompt from script and question
  */
-export const buildUserPrompt = (script: ExtendedScript, question: string): string => {
+export const buildUserPrompt = (script: ExtendedMulmoScript, question: string): string => {
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)
@@ -92,7 +92,7 @@ export const getInteractiveSystemPrompt = (options: QueryOptions): string => {
 /**
  * Build user prompt with conversation history for interactive mode
  */
-export const buildInteractiveUserPrompt = (script: ExtendedScript, question: string, history: ConversationMessage[]): string => {
+export const buildInteractiveUserPrompt = (script: ExtendedMulmoScript, question: string, history: ConversationMessage[]): string => {
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/index.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/index.ts
@@ -1,4 +1,4 @@
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { SummarizeOptions, SummarizeResult } from "../../../../types/summarize.js";
 import { summarizeOptionsSchema } from "../../../../types/summarize.js";
 import { executeLLM, filterScript } from "../../llm.js";
@@ -7,7 +7,7 @@ import { buildUserPrompt, getSystemPrompt } from "./prompts.js";
 /**
  * Main summarize function - generates a summary of the entire script
  */
-export const summarizeScript = async (script: ExtendedScript, options: Partial<SummarizeOptions> = {}): Promise<SummarizeResult> => {
+export const summarizeScript = async (script: ExtendedMulmoScript, options: Partial<SummarizeOptions> = {}): Promise<SummarizeResult> => {
   // Validate and apply defaults
   const validatedOptions = summarizeOptionsSchema.parse(options);
 

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
@@ -1,5 +1,5 @@
 import type { SummarizeOptions } from "../../../../types/summarize.js";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import { getLanguageName, buildScriptContent } from "../../llm.js";
 
 /**
@@ -26,7 +26,7 @@ export const DEFAULT_SYSTEM_PROMPT_MARKDOWN = `You are creating a summary based 
 /**
  * Build user prompt from entire script
  */
-export const buildUserPrompt = (script: ExtendedScript, options: SummarizeOptions): string => {
+export const buildUserPrompt = (script: ExtendedMulmoScript, options: SummarizeOptions): string => {
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)

--- a/packages/mulmocast-preprocessor/src/core/ai/llm.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/llm.ts
@@ -7,7 +7,7 @@ import { anthropicAgent } from "@graphai/anthropic_agent";
 import { groqAgent } from "@graphai/groq_agent";
 import { geminiAgent } from "@graphai/gemini_agent";
 
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { LLMProvider } from "../../types/summarize.js";
 import { filterBySection, filterByTags } from "../preprocessing/filter.js";
 
@@ -118,7 +118,7 @@ const createLLMGraph = (agentName: string): GraphData => ({
 /**
  * Filter script based on options (section, tags)
  */
-export const filterScript = (script: ExtendedScript, options: BaseLLMOptions): ExtendedScript => {
+export const filterScript = (script: ExtendedMulmoScript, options: BaseLLMOptions): ExtendedMulmoScript => {
   const afterSection = options.section ? filterBySection(script, options.section) : script;
   const afterTags = options.tags && options.tags.length > 0 ? filterByTags(afterSection, options.tags) : afterSection;
   return afterTags;
@@ -146,7 +146,7 @@ export const getLanguageName = (langCode: string): string => {
 /**
  * Build beat content including metadata
  */
-const buildBeatContent = (beat: ExtendedScript["beats"][number], index: number): string => {
+const buildBeatContent = (beat: ExtendedMulmoScript["beats"][number], index: number): string => {
   const lines: string[] = [];
 
   // Main text
@@ -182,7 +182,7 @@ const buildBeatContent = (beat: ExtendedScript["beats"][number], index: number):
 /**
  * Build script-level metadata section
  */
-const buildScriptMetaContent = (script: ExtendedScript): string => {
+const buildScriptMetaContent = (script: ExtendedMulmoScript): string => {
   const meta = script.scriptMeta;
   if (!meta) return "";
 
@@ -241,7 +241,7 @@ const buildScriptMetaContent = (script: ExtendedScript): string => {
 /**
  * Build script content for user prompt (common part)
  */
-export const buildScriptContent = (script: ExtendedScript): string => {
+export const buildScriptContent = (script: ExtendedMulmoScript): string => {
   const parts: string[] = [];
 
   // Add script title and language
@@ -294,10 +294,10 @@ export interface CommandResult {
  * Execute a command (summarize, query, etc.) with common logic
  */
 export const executeCommand = async <T extends BaseLLMOptions>(
-  script: ExtendedScript,
+  script: ExtendedMulmoScript,
   options: T,
   getSystemPrompt: (opts: T) => string,
-  buildUserPrompt: (script: ExtendedScript) => string,
+  buildUserPrompt: (script: ExtendedMulmoScript) => string,
   verboseMessage: string,
 ): Promise<CommandResult | null> => {
   const filteredScript = filterScript(script, options);

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/filter.ts
@@ -1,12 +1,12 @@
 import type { MulmoScript, MulmoBeat } from "@mulmocast/types";
-import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript, ExtendedMulmoBeat } from "@mulmocast/extended-types";
 
-const stripBeatExtendedFields = (beat: ExtendedBeat): MulmoBeat => {
+const stripBeatExtendedFields = (beat: ExtendedMulmoBeat): MulmoBeat => {
   const { variants: __variants, meta: __meta, ...baseBeat } = beat;
   return baseBeat;
 };
 
-const filterBeatsToMulmoScript = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): MulmoScript => {
+const filterBeatsToMulmoScript = (script: ExtendedMulmoScript, predicate: (beat: ExtendedMulmoBeat) => boolean): MulmoScript => {
   const { outputProfiles: __outputProfiles, scriptMeta: __scriptMeta, ...baseScript } = script;
   return {
     ...baseScript,
@@ -14,7 +14,7 @@ const filterBeatsToMulmoScript = (script: ExtendedScript, predicate: (beat: Exte
   } as MulmoScript;
 };
 
-const filterBeatsPreservingMeta = (script: ExtendedScript, predicate: (beat: ExtendedBeat) => boolean): ExtendedScript => ({
+const filterBeatsPreservingMeta = (script: ExtendedMulmoScript, predicate: (beat: ExtendedMulmoBeat) => boolean): ExtendedMulmoScript => ({
   ...script,
   beats: script.beats.filter(predicate),
 });
@@ -22,13 +22,13 @@ const filterBeatsPreservingMeta = (script: ExtendedScript, predicate: (beat: Ext
 /**
  * Filter beats by section (preserves meta for chaining)
  */
-export const filterBySection = (script: ExtendedScript, section: string): ExtendedScript =>
+export const filterBySection = (script: ExtendedMulmoScript, section: string): ExtendedMulmoScript =>
   filterBeatsPreservingMeta(script, (beat) => beat.meta?.section === section);
 
 /**
  * Filter beats by tags (preserves meta for chaining)
  */
-export const filterByTags = (script: ExtendedScript, tags: string[]): ExtendedScript => {
+export const filterByTags = (script: ExtendedMulmoScript, tags: string[]): ExtendedMulmoScript => {
   const tagSet = new Set(tags);
   return filterBeatsPreservingMeta(script, (beat) => (beat.meta?.tags ?? []).some((tag) => tagSet.has(tag)));
 };
@@ -36,4 +36,4 @@ export const filterByTags = (script: ExtendedScript, tags: string[]): ExtendedSc
 /**
  * Strip variants and meta fields, converting to standard MulmoScript
  */
-export const stripExtendedFields = (script: ExtendedScript): MulmoScript => filterBeatsToMulmoScript(script, () => true);
+export const stripExtendedFields = (script: ExtendedMulmoScript): MulmoScript => filterBeatsToMulmoScript(script, () => true);

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/process.ts
@@ -1,5 +1,5 @@
 import type { MulmoScript } from "@mulmocast/types";
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { ProcessOptions } from "../../types/index.js";
 import { applyProfile } from "./variant.js";
 import { filterBySection, filterByTags, stripExtendedFields } from "./filter.js";
@@ -8,7 +8,7 @@ import { filterBySection, filterByTags, stripExtendedFields } from "./filter.js"
  * Main processing function
  * Applies filters first (while meta exists), then profile
  */
-export const processScript = (script: ExtendedScript, options: ProcessOptions = {}): MulmoScript => {
+export const processScript = (script: ExtendedMulmoScript, options: ProcessOptions = {}): MulmoScript => {
   const afterSection = options.section ? filterBySection(script, options.section) : script;
 
   const afterTags = options.tags && options.tags.length > 0 ? filterByTags(afterSection, options.tags) : afterSection;

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/profiles.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/profiles.ts
@@ -1,10 +1,10 @@
-import type { ExtendedScript } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { ProfileInfo } from "../../types/index.js";
 
 /**
  * Get list of available profiles from script
  */
-export const listProfiles = (script: ExtendedScript): ProfileInfo[] => {
+export const listProfiles = (script: ExtendedMulmoScript): ProfileInfo[] => {
   const profileNames = new Set<string>(["default"]);
 
   script.beats

--- a/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
+++ b/packages/mulmocast-preprocessor/src/core/preprocessing/variant.ts
@@ -1,11 +1,11 @@
 import type { MulmoScript, MulmoBeat } from "@mulmocast/types";
-import type { ExtendedScript, ExtendedBeat } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript, ExtendedMulmoBeat } from "@mulmocast/extended-types";
 
 /**
  * Apply profile variant to a single beat
  * @returns Processed beat, or null if skip is set
  */
-const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat | null => {
+const applyVariantToBeat = (beat: ExtendedMulmoBeat, profileName: string): MulmoBeat | null => {
   const variant = beat.variants?.[profileName];
 
   if (variant?.skip) {
@@ -25,7 +25,7 @@ const applyVariantToBeat = (beat: ExtendedBeat, profileName: string): MulmoBeat 
 /**
  * Apply profile to script and return standard MulmoScript
  */
-export const applyProfile = (script: ExtendedScript, profileName: string): MulmoScript => {
+export const applyProfile = (script: ExtendedMulmoScript, profileName: string): MulmoScript => {
   const { outputProfiles: __outputProfiles, scriptMeta: __scriptMeta, ...baseScript } = script;
 
   return {

--- a/packages/mulmocast-preprocessor/src/index.ts
+++ b/packages/mulmocast-preprocessor/src/index.ts
@@ -28,8 +28,8 @@ export type { FetchedContent } from "./core/ai/utils/fetcher.js";
 export type {
   BeatVariant,
   BeatMeta,
-  ExtendedBeat,
-  ExtendedScript,
+  ExtendedMulmoBeat,
+  ExtendedMulmoScript,
   OutputProfile,
   Reference,
   FAQ,
@@ -39,8 +39,8 @@ export type {
 export {
   beatVariantSchema,
   beatMetaSchema,
-  extendedBeatSchema,
-  extendedScriptSchema,
+  extendedMulmoBeatSchema,
+  extendedMulmoScriptSchema,
   outputProfileSchema,
   referenceSchema,
   faqSchema,

--- a/packages/mulmocast-preprocessor/test/test_summarize.ts
+++ b/packages/mulmocast-preprocessor/test/test_summarize.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { buildUserPrompt, getSystemPrompt, DEFAULT_SYSTEM_PROMPT_TEXT, DEFAULT_SYSTEM_PROMPT_MARKDOWN } from "../src/core/ai/command/summarize/prompts.js";
 import { getProviderConfig } from "../src/core/ai/llm.js";
-import type { ExtendedScript } from "../src/index.js";
+import type { ExtendedMulmoScript } from "../src/index.js";
 import type { SummarizeOptions } from "../src/types/summarize.js";
 
 const createTestOptions = (overrides?: Partial<SummarizeOptions>): SummarizeOptions => ({
@@ -12,7 +12,7 @@ const createTestOptions = (overrides?: Partial<SummarizeOptions>): SummarizeOpti
   ...overrides,
 });
 
-const createTestScript = (): ExtendedScript => ({
+const createTestScript = (): ExtendedMulmoScript => ({
   $mulmocast: { version: "1.1" },
   title: "Test Script",
   lang: "en",
@@ -87,7 +87,7 @@ describe("buildUserPrompt", () => {
   });
 
   it("should include metadata (tags, context, keywords, expectedQuestions)", () => {
-    const script: ExtendedScript = {
+    const script: ExtendedMulmoScript = {
       $mulmocast: { version: "1.1" },
       title: "Metadata Test",
       lang: "en",

--- a/packages/mulmocast-preprocessor/test/test_variant.ts
+++ b/packages/mulmocast-preprocessor/test/test_variant.ts
@@ -1,10 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { applyProfile, listProfiles, processScript, filterBySection, filterByTags, stripExtendedFields } from "../src/index.js";
-import type { ExtendedScript } from "../src/index.js";
+import type { ExtendedMulmoScript } from "../src/index.js";
 import { mulmoScriptSchema } from "@mulmocast/types";
 
-const createTestScript = (): ExtendedScript => ({
+const createTestScript = (): ExtendedMulmoScript => ({
   $mulmocast: { version: "1.1" },
   title: "Test Script",
   lang: "ja",

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,14 +564,6 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/extended-types@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mulmocast/extended-types/-/extended-types-0.1.0.tgz#fc615728cd6698b84d84d73d4f4f4d4f09819d16"
-  integrity sha512-K+rJ1Eiea+geOVLmxtuJd+b+LMAq3D7BFFPtZ2POAPGpgjaK3Oe4qk7betnOIIMnGGNKqKuNU9PEXaPdNItZag==
-  dependencies:
-    mulmocast "^2.1.35"
-    zod "^4.3.6"
-
 "@mulmocast/types@^2.1.35":
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.35.tgz#63c961deb27090a1861c153200b5e2fe8042c68d"


### PR DESCRIPTION
## Summary
- Rename `ExtendedScript` → `ExtendedMulmoScript`, `ExtendedBeat` → `ExtendedMulmoBeat` to clarify inheritance from `MulmoScript`/`MulmoBeat`
- Rename schemas: `extendedScriptSchema` → `extendedMulmoScriptSchema`, `extendedBeatSchema` → `extendedMulmoBeatSchema`
- Bump `@mulmocast/extended-types` to 0.3.0 (breaking change)
- Update all imports, usages, tests, and documentation across both packages

## User Prompt
`ExtendedScript` / `ExtendedBeat` は `MulmoScript` / `MulmoBeat` を継承した型だが、名前から親型との関連が分かりにくい。`ExtendedMulmoScript` / `ExtendedMulmoBeat` にリネームして命名を統一する。旧名は残さず一括置換。

## Test plan
- [x] `mulmocast-extended-types`: `yarn build` passes
- [x] `mulmocast-extended-types`: `yarn test` passes (22 tests)
- [x] `mulmocast-preprocessor`: `yarn build` passes
- [x] `mulmocast-preprocessor`: `yarn test` passes (39 tests)
- [x] No old names remain (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)