### PR TITLE
fix: update preprocessor test imports after re-export removal

### DIFF
--- a/packages/mulmocast-preprocessor/test/test_summarize.ts
+++ b/packages/mulmocast-preprocessor/test/test_summarize.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { buildUserPrompt, getSystemPrompt, DEFAULT_SYSTEM_PROMPT_TEXT, DEFAULT_SYSTEM_PROMPT_MARKDOWN } from "../src/core/ai/command/summarize/prompts.js";
 import { getProviderConfig } from "../src/core/ai/llm.js";
-import type { ExtendedMulmoScript } from "../src/index.js";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { SummarizeOptions } from "../src/types/summarize.js";
 
 const createTestOptions = (overrides?: Partial<SummarizeOptions>): SummarizeOptions => ({

--- a/packages/mulmocast-preprocessor/test/test_variant.ts
+++ b/packages/mulmocast-preprocessor/test/test_variant.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { applyProfile, listProfiles, processScript, filterBySection, filterByTags, stripExtendedFields } from "../src/index.js";
-import type { ExtendedMulmoScript } from "../src/index.js";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import { mulmoScriptSchema } from "@mulmocast/types";
 
 const createTestScript = (): ExtendedMulmoScript => ({


### PR DESCRIPTION
## Summary
- Update test imports in `test_summarize.ts` and `test_variant.ts` to import `ExtendedMulmoScript` directly from `@mulmocast/extended-types` instead of `../src/index.js`
- This follows the re-export removal done in PR #32

## User Prompt
- Follow-up fix from the ExtendedScript → ExtendedMulmoScript rename: after removing re-exports of extended-types from preprocessor's index.ts, test imports need to point directly to @mulmocast/extended-types

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (71 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)