### PR TITLE
chore: bump mulmocast-preprocessor to 0.5.0

### DIFF
--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-preprocessor",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Preprocessor for MulmoScript",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-preprocessor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Preprocessor for MulmoScript",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary
- Bump mulmocast-preprocessor version from 0.4.1 to 0.5.0
- Published to npm as mulmocast-preprocessor@0.5.0
- Breaking change: removed re-exports of @mulmocast/extended-types (consumers should import types directly)

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (71 tests)
- [x] Published to npm successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)