### PR TITLE
feat: add mulmocast-mcp package to monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Monorepo for MulmoCast CLI derivative packages. Extended functionality for the MulmoCast platform.
+Monorepo for MulmoCast derivative packages. Extended functionality for the MulmoCast platform.
 
 ## Commands
 
@@ -15,9 +15,58 @@ yarn format     # Format all packages
 yarn test       # Run tests across all packages
 ```
 
+Per-package commands (run from `packages/<name>/`):
+
+```bash
+yarn build      # tsc
+yarn lint       # eslint src
+yarn format     # prettier --write
+yarn test       # node --import tsx --test (where available)
+```
+
 ## Architecture
 
-Yarn workspaces monorepo with packages:
-- `packages/mulmocast-easy/` - Simplified MulmoCast interface
-- `packages/mulmocast-extended-types/` - Extended type definitions
-- `packages/mulmocast-preprocessor/` - Content preprocessor
+Yarn workspaces monorepo (`packages/*`). Shared TypeScript config at `config/tsconfig.base.json` — each package extends it via `"extends": "../../config/tsconfig.base.json"`.
+
+### Packages
+
+| Package | npm name | Description |
+|---------|----------|-------------|
+| `mulmocast-easy` | `mulmocast-easy` | MulmoCast with bundled ffmpeg for easy installation |
+| `mulmocast-extended-types` | `@mulmocast/extended-types` | Zod schemas and types extending `@mulmocast/types` |
+| `mulmocast-preprocessor` | `mulmocast-preprocessor` | Content preprocessor (filter, variant, profile, AI query/summarize) |
+| `mulmocast-mcp` | `mulmocast-mcp` | MCP (Model Context Protocol) server for MulmoCast |
+
+### mulmocast-extended-types — Type Structure
+
+Source files under `packages/mulmocast-extended-types/src/`:
+
+- **`mulmoBeat.ts`** — Extends `MulmoBeat` / `MulmoScript` from `@mulmocast/types`
+  - `beatVariantSchema` / `BeatVariant` — profile-specific content overrides
+  - `beatMetaSchema` / `BeatMeta` — metadata for filtering and context
+  - `extendedMulmoBeatSchema` / `ExtendedMulmoBeat` — beat with variants and meta
+  - `outputProfileSchema` / `OutputProfile` — profile display information
+  - `referenceSchema` / `Reference` — external resource reference
+  - `faqSchema` / `FAQ` — frequently asked question
+  - `scriptMetaSchema` / `ScriptMeta` — script-level metadata for AI features
+  - `extendedMulmoScriptSchema` / `ExtendedMulmoScript` — script with extended beats, outputProfiles, scriptMeta
+
+- **`mulmoViewerData.ts`** — Extends `MulmoViewerBeat` / `MulmoViewerData` from `@mulmocast/types`
+  - `extendedMulmoViewerBeatSchema` / `ExtendedMulmoViewerBeat` — viewer beat with variants and meta
+  - `extendedMulmoViewerDataSchema` / `ExtendedMulmoViewerData` — viewer data with extended beats, outputProfiles, scriptMeta
+
+- **`index.ts`** — Barrel file re-exporting from `mulmoBeat.js` and `mulmoViewerData.js`
+
+### Naming Conventions
+
+- Type names: `ExtendedMulmoScript`, `ExtendedMulmoBeat`, `ExtendedMulmoViewerBeat`, `ExtendedMulmoViewerData`
+- Schema names: `extendedMulmoScriptSchema`, `extendedMulmoBeatSchema`, etc.
+- Never use the old short names (`ExtendedScript`, `ExtendedBeat`, `extendedScriptSchema`, `extendedBeatSchema`)
+
+### mulmocast-mcp
+
+MCP server providing MulmoCast content generation tools. Migrated from standalone repository `receptron/mulmocast-mcp` (now archived).
+
+- Entry point: `src/index.ts` (also the bin target)
+- License: AGPL-3.0-only (different from other MIT-licensed packages)
+- Uses `@modelcontextprotocol/sdk` for MCP protocol, `mulmocast` for generation

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Monorepo for MulmoCast extension packages.
 |---------|-------------|-----|
 | [mulmocast-easy](./packages/mulmocast-easy) | MulmoCast with zero configuration (ffmpeg/Chrome bundled) | [![npm](https://img.shields.io/npm/v/mulmocast-easy)](https://www.npmjs.com/package/mulmocast-easy) |
 | [mulmocast-preprocessor](./packages/mulmocast-preprocessor) | Profile variants, filtering, AI summarization & Q&A | [![npm](https://img.shields.io/npm/v/mulmocast-preprocessor)](https://www.npmjs.com/package/mulmocast-preprocessor) |
-| [@mulmocast/extended-types](./packages/mulmocast-extended-types) | Type definitions and Zod schemas for ExtendedScript | [![npm](https://img.shields.io/npm/v/@mulmocast/extended-types)](https://www.npmjs.com/package/@mulmocast/extended-types) |
+| [@mulmocast/extended-types](./packages/mulmocast-extended-types) | Type definitions and Zod schemas for ExtendedMulmoScript | [![npm](https://img.shields.io/npm/v/@mulmocast/extended-types)](https://www.npmjs.com/package/@mulmocast/extended-types) |
+| [mulmocast-mcp](./packages/mulmocast-mcp) | MCP (Model Context Protocol) server for MulmoCast | [![npm](https://img.shields.io/npm/v/mulmocast-mcp)](https://www.npmjs.com/package/mulmocast-mcp) |
 
 ## Development
 
@@ -41,4 +42,4 @@ yarn test     # Test all packages
 
 ## License
 
-MIT
+MIT (except `mulmocast-mcp`: AGPL-3.0-only)

--- a/packages/mulmocast-mcp/README.md
+++ b/packages/mulmocast-mcp/README.md
@@ -1,0 +1,31 @@
+[![npm version](https://badge.fury.io/js/mulmocast-mcp.svg)](https://badge.fury.io/js/mulmocast-mcp)
+# mulmocast-mcp
+
+MCP (Model Context Protocol) server for MulmoCast.
+
+## Usage
+
+```json
+    "mulmocast": {
+      "command": "npx",
+      "args": [
+        "mulmocast-mcp@latest"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "xxx",
+        "REPLICATE_API_TOKEN": "xxx",
+        "ANTHROPIC_API_KEY": "xxx"
+      },
+      "transport": {
+        "stdio": true
+      }
+    }
+```
+
+## Commands
+
+```bash
+yarn build      # Compile TypeScript (tsc)
+yarn lint       # Run ESLint on src/
+yarn format     # Format with Prettier
+```

--- a/packages/mulmocast-mcp/package.json
+++ b/packages/mulmocast-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "mulmocast-mcp",
+  "version": "1.0.1",
+  "description": "MCP (Model Context Protocol) server for MulmoCast",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "bin": {
+    "mulmocast-mcp": "lib/index.js"
+  },
+  "files": [
+    "./lib"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src",
+    "format": "prettier --write 'src/**/*.ts'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmocast-plus.git"
+  },
+  "author": "receptron",
+  "license": "AGPL-3.0-only",
+  "bugs": {
+    "url": "https://github.com/receptron/mulmocast-plus/issues"
+  },
+  "homepage": "https://github.com/receptron/mulmocast-plus#readme",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "dotenv": "^17.2.4",
+    "mulmocast": "^2.1.35",
+    "zod": "^4.3.6"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/packages/mulmocast-mcp/package.json
+++ b/packages/mulmocast-mcp/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
+    "test": "echo nothing",
     "format": "prettier --write 'src/**/*.ts'"
   },
   "repository": {

--- a/packages/mulmocast-mcp/src/html_prompt.json
+++ b/packages/mulmocast-mcp/src/html_prompt.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "$mulmocast": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "const": "1.0"
+        }
+      },
+      "required": ["version"],
+      "additionalProperties": false
+    },
+    "canvasSize": {
+      "type": "object",
+      "properties": {
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      },
+      "required": ["width", "height"],
+      "additionalProperties": false,
+      "default": { "width": 1280, "height": 720 }
+    },
+    "htmlImageParams": {
+      "type": "object",
+      "properties": {
+        "provider": { "enum": ["anthropic"] }
+      },
+      "required": ["provider"],
+      "additionalProperties": false,
+      "default": { "provider": "anthropic" }
+    },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "lang": { "type": "string" },
+    "beats": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "text": { "type": "string", "default": "" },
+          "htmlPrompt": {
+            "type": "object",
+            "properties": {
+              "prompt": { "type": "string" }
+            },
+            "required": ["prompt"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["text", "htmlPrompt"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["$mulmocast", "beats"],
+  "additionalProperties": false
+}

--- a/packages/mulmocast-mcp/src/index.ts
+++ b/packages/mulmocast-mcp/src/index.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+import dotenv from "dotenv";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, CallToolRequest, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { GraphAILogger } from "graphai";
+import {
+  audio,
+  images,
+  movie,
+  captions,
+  pdf,
+  html,
+  getFileObject,
+  initializeContextFromFiles,
+  runTranslateIfNeeded,
+  outDirName,
+  resolveDirPath,
+  mkdir,
+  generateTimestampedFileName,
+  MulmoScriptMethods,
+  type MulmoScript,
+  updateNpmRoot,
+} from "mulmocast";
+
+// Load MulmoScript JSON Schema from file
+import MULMO_SCRIPT_JSON_SCHEMA from "./html_prompt.json" with { type: "json" };
+
+dotenv.config({ quiet: true });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+updateNpmRoot(path.resolve(__dirname, "../node_modules/mulmocast"));
+
+const server = new Server(
+  {
+    name: "mulmocast-mcp",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+);
+
+export const formattedDate = () => {
+  const now = new Date();
+
+  const formatted = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("-");
+  return formatted;
+};
+
+export const getBaseDir = () => {
+  return path.join(os.homedir(), "Documents", "mulmocast");
+};
+export const getOutDir = () => {
+  return path.join(getBaseDir(), formattedDate());
+};
+
+// Helper function to save MulmoScript content to output directory
+const saveMulmoScriptToOutput = async (mulmoScript: MulmoScript): Promise<string> => {
+  const outputDirPath = path.resolve(getOutDir(), outDirName);
+
+  // Create timestamp-based filename similar to __clipboard handling
+  const fileName = generateTimestampedFileName("mcp_script");
+
+  // Ensure output directory exists
+
+  // GraphAILogger.error(outputDirPath);
+  mkdir(outputDirPath);
+
+  // Save MulmoScript to file
+  const filePath = resolveDirPath(outputDirPath, `${fileName}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(mulmoScript, null, 2), "utf8");
+
+  return filePath;
+};
+
+// List available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "generate",
+        description: "Generate movie, image, audio, html from MulmoScript content",
+        inputSchema: {
+          type: "object",
+          properties: {
+            cmd: {
+              type: "string",
+              enum: ["audio", "image", "movie", "html"],
+              description: "Command to execute: 'movie' to generate video, 'image' to generate Image",
+            },
+            mulmoScript: MULMO_SCRIPT_JSON_SCHEMA,
+            options: {
+              type: "object",
+              description: "Optional generation parameters",
+              properties: {
+                pdfMode: { type: "string", enum: ["slide", "talk", "handout"], description: "PDF generation mode (for PDF only)" },
+                pdfSize: { type: "string", enum: ["A4", "Letter", "Legal"], description: "PDF page size (for PDF only)" },
+                lang: { type: "string", description: "Language for translation" },
+                caption: { type: "string", description: "Caption language" },
+                force: { type: "boolean", description: "Force regeneration" },
+                verbose: { type: "boolean", description: "Enable verbose logging" },
+              },
+              additionalProperties: false,
+            },
+          },
+          required: ["cmd", "mulmoScript"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  };
+});
+
+// Handle tool calls
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    if (name !== "generate") {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+
+    const {
+      cmd,
+      mulmoScript,
+      options = {},
+    } = args as {
+      cmd: "movie" | "pdf" | "html" | "audio" | "image";
+      mulmoScript: MulmoScript;
+      options?: {
+        pdfMode?: string;
+        pdfSize?: string;
+        lang?: string;
+        caption?: string;
+        force?: boolean;
+        verbose?: boolean;
+      };
+    };
+
+    // Validate MulmoScript schema
+    const validatedScript = MulmoScriptMethods.validate(mulmoScript);
+
+    // Save MulmoScript to output directory
+    const filePath = await saveMulmoScriptToOutput(validatedScript);
+
+    // Create argv-like object for CLI compatibility
+    const files = getFileObject({
+      basedir: getBaseDir(),
+      outdir: getOutDir(),
+      //imagedir?: string;
+      // audiodir?: string;
+      // presentationStyle?: string;
+      file: filePath,
+    });
+
+    // Initialize context using the saved file
+    // const context = await initializeContext(argv);
+    const context = await initializeContextFromFiles(files, false, options.force || false, false, options.caption, options.lang);
+
+    if (!context) {
+      throw new Error("Failed to initialize context from MulmoScript");
+    }
+
+    // Run translation if needed
+    await runTranslateIfNeeded(context);
+
+    // Execute the requested command
+    // enum: ["audio", "image", "movie", "pdf", "html"],
+    if (cmd === "audio") {
+      await audio(context);
+    } else if (cmd === "image") {
+      await images(context);
+    } else if (cmd === "movie") {
+      // Generate movie (audio + images + captions + movie)
+      await audio(context).then(images).then(captions).then(movie);
+    } else if (cmd === "pdf") {
+      // Generate images first, then PDF
+      await images(context).then((imageContext) => pdf(imageContext, options.pdfMode || "handout", options.pdfSize || "Letter"));
+    } else if (cmd === "html") {
+      await images(context).then((imageContext) => html(imageContext));
+    } else {
+      throw new Error(`Unknown command: ${cmd}. Supported commands: audio, image, movie, html `);
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `${cmd} generated successfully from MulmoScript. Output saved to: ${context?.fileDirs.outDirPath}`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start the server
+async function main() {
+  // eslint-disable-next-line no-console
+  const logger = (level: string, ...args: unknown[]) => console.error(...args);
+  GraphAILogger.setLogger(logger);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  GraphAILogger.error("MulmoCast MCP Server running on stdio");
+}
+
+main().catch((error) => {
+  GraphAILogger.error("Failed to start MCP server:", error);
+  process.exit(1);
+});

--- a/packages/mulmocast-mcp/tsconfig.json
+++ b/packages/mulmocast-mcp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,7 +513,7 @@
   resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
   integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
 
-"@isaacs/brace-expansion@^5.0.0", "@isaacs/brace-expansion@^5.0.1":
+"@isaacs/brace-expansion@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
   integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
@@ -565,7 +565,7 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/types@2.1.37", "@mulmocast/types@^2.1.35":
+"@mulmocast/types@^2.1.35", "@mulmocast/types@^2.1.37":
   version "2.1.37"
   resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.37.tgz#02c3305bc9a92f6637fdbfb21ca92c3abbf9dfc5"
   integrity sha512-f1kHUUiVLaUUetOyEqvjtwz+ISzjSYmurkYXDL7pl4J4fHyRlasslBRqwiQHKKuknQmf1AzJQFM2FGk0sRw3lg==
@@ -707,7 +707,7 @@
     "@types/node" "*"
     form-data "^4.0.4"
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^25.2.1", "@types/node@^25.2.3":
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^25.2.1":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.2.3.tgz#9c18245be768bdb4ce631566c7da303a5c99a7f8"
   integrity sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==
@@ -745,20 +745,6 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz#d8899e5c2eccf5c4a20d01c036a193753748454d"
-  integrity sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==
-  dependencies:
-    "@eslint-community/regexpp" "^4.12.2"
-    "@typescript-eslint/scope-manager" "8.54.0"
-    "@typescript-eslint/type-utils" "8.54.0"
-    "@typescript-eslint/utils" "8.54.0"
-    "@typescript-eslint/visitor-keys" "8.54.0"
-    ignore "^7.0.5"
-    natural-compare "^1.4.0"
-    ts-api-utils "^2.4.0"
-
 "@typescript-eslint/eslint-plugin@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz#086d2ef661507b561f7b17f62d3179d692a0765f"
@@ -773,17 +759,6 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/parser@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.54.0.tgz#3d01a6f54ed247deb9982621f70e7abf1810bd97"
-  integrity sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "8.54.0"
-    "@typescript-eslint/types" "8.54.0"
-    "@typescript-eslint/typescript-estree" "8.54.0"
-    "@typescript-eslint/visitor-keys" "8.54.0"
-    debug "^4.4.3"
-
 "@typescript-eslint/parser@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.55.0.tgz#6eace4e9e95f178d3447ed1f17f3d6a5dfdb345c"
@@ -795,15 +770,6 @@
     "@typescript-eslint/visitor-keys" "8.55.0"
     debug "^4.4.3"
 
-"@typescript-eslint/project-service@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.54.0.tgz#f582aceb3d752544c8e1b11fea8d95d00cf9adc6"
-  integrity sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==
-  dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.54.0"
-    "@typescript-eslint/types" "^8.54.0"
-    debug "^4.4.3"
-
 "@typescript-eslint/project-service@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.55.0.tgz#b8a71c06a625bdad481c24d5614b68e252f3ae9b"
@@ -813,14 +779,6 @@
     "@typescript-eslint/types" "^8.55.0"
     debug "^4.4.3"
 
-"@typescript-eslint/scope-manager@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz#307dc8cbd80157e2772c2d36216857415a71ab33"
-  integrity sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==
-  dependencies:
-    "@typescript-eslint/types" "8.54.0"
-    "@typescript-eslint/visitor-keys" "8.54.0"
-
 "@typescript-eslint/scope-manager@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz#8a0752c31c788651840dc98f840b0c2ebe143b8c"
@@ -829,26 +787,10 @@
     "@typescript-eslint/types" "8.55.0"
     "@typescript-eslint/visitor-keys" "8.55.0"
 
-"@typescript-eslint/tsconfig-utils@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz#71dd7ba1674bd48b172fc4c85b2f734b0eae3dbc"
-  integrity sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==
-
-"@typescript-eslint/tsconfig-utils@8.55.0", "@typescript-eslint/tsconfig-utils@^8.54.0", "@typescript-eslint/tsconfig-utils@^8.55.0":
+"@typescript-eslint/tsconfig-utils@8.55.0", "@typescript-eslint/tsconfig-utils@^8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.55.0.tgz#62f1d005419985e09d37a040b2f1450e4e805afa"
   integrity sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==
-
-"@typescript-eslint/type-utils@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz#64965317dd4118346c2fa5ee94492892200e9fb9"
-  integrity sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==
-  dependencies:
-    "@typescript-eslint/types" "8.54.0"
-    "@typescript-eslint/typescript-estree" "8.54.0"
-    "@typescript-eslint/utils" "8.54.0"
-    debug "^4.4.3"
-    ts-api-utils "^2.4.0"
 
 "@typescript-eslint/type-utils@8.55.0":
   version "8.55.0"
@@ -861,30 +803,10 @@
     debug "^4.4.3"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/types@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.54.0.tgz#c12d41f67a2e15a8a96fbc5f2d07b17331130889"
-  integrity sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==
-
-"@typescript-eslint/types@8.55.0", "@typescript-eslint/types@^8.54.0", "@typescript-eslint/types@^8.55.0":
+"@typescript-eslint/types@8.55.0", "@typescript-eslint/types@^8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.55.0.tgz#8449c5a7adac61184cac92dbf6315733569708c2"
   integrity sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==
-
-"@typescript-eslint/typescript-estree@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz#3c7716905b2b811fadbd2114804047d1bfc86527"
-  integrity sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==
-  dependencies:
-    "@typescript-eslint/project-service" "8.54.0"
-    "@typescript-eslint/tsconfig-utils" "8.54.0"
-    "@typescript-eslint/types" "8.54.0"
-    "@typescript-eslint/visitor-keys" "8.54.0"
-    debug "^4.4.3"
-    minimatch "^9.0.5"
-    semver "^7.7.3"
-    tinyglobby "^0.2.15"
-    ts-api-utils "^2.4.0"
 
 "@typescript-eslint/typescript-estree@8.55.0":
   version "8.55.0"
@@ -901,16 +823,6 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.4.0"
 
-"@typescript-eslint/utils@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.54.0.tgz#c79a4bcbeebb4f571278c0183ed1cb601d84c6c8"
-  integrity sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.9.1"
-    "@typescript-eslint/scope-manager" "8.54.0"
-    "@typescript-eslint/types" "8.54.0"
-    "@typescript-eslint/typescript-estree" "8.54.0"
-
 "@typescript-eslint/utils@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.55.0.tgz#c1744d94a3901deb01f58b09d3478d811f96d619"
@@ -920,14 +832,6 @@
     "@typescript-eslint/scope-manager" "8.55.0"
     "@typescript-eslint/types" "8.55.0"
     "@typescript-eslint/typescript-estree" "8.55.0"
-
-"@typescript-eslint/visitor-keys@8.54.0":
-  version "8.54.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz#0e4b50124b210b8600b245dd66cbad52deb15590"
-  integrity sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==
-  dependencies:
-    "@typescript-eslint/types" "8.54.0"
-    eslint-visitor-keys "^4.2.1"
 
 "@typescript-eslint/visitor-keys@8.55.0":
   version "8.55.0"
@@ -1738,7 +1642,7 @@ eslint-plugin-prettier@^5.5.5:
     prettier-linter-helpers "^1.0.1"
     synckit "^0.11.12"
 
-eslint-plugin-sonarjs@^3.0.6, eslint-plugin-sonarjs@^3.0.7:
+eslint-plugin-sonarjs@^3.0.6:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.7.tgz#c2787b1a7a5f918b5b902daf66af056dea64e03c"
   integrity sha512-62jB20krIPvcwBLAyG3VVKa2ce2j2lL1yCb8Y0ylMRR/dLvCCTiQx8gQbXb+G81k1alPZ2/I3muZinqWQdBbzw==
@@ -2899,13 +2803,6 @@ mimic-function@^5.0.0:
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-minimatch@10.1.1:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.1.1.tgz#e6e61b9b0c1dcab116b5a7d1458e8b6ae9e73a55"
-  integrity sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==
-  dependencies:
-    "@isaacs/brace-expansion" "^5.0.0"
-
 minimatch@10.1.2, minimatch@^10.1.1:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.1.2.tgz#6c3f289f9de66d628fa3feb1842804396a43d81c"
@@ -2952,7 +2849,7 @@ mulmocast-vision@^1.0.8:
     pdfkit "^0.17.2"
     puppeteer "^24.32.0"
 
-mulmocast@^2.1.37:
+mulmocast@^2.1.35, mulmocast@^2.1.37:
   version "2.1.37"
   resolved "https://registry.yarnpkg.com/mulmocast/-/mulmocast-2.1.37.tgz#dd54543206b6be3c3c52feac5775665320d01a72"
   integrity sha512-b+PKtziVcfGEOtuIHJhxCfWFBZyf9Vd3i5X8e4RDQgDaOY/p8ELReSmjyr9I6VY3AG4LbmLuH0BbrKcMCtExBg==
@@ -3611,11 +3508,6 @@ scslre@0.3.0:
     refa "^0.12.0"
     regexp-ast-analysis "^0.7.0"
 
-semver@7.7.3:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
-  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
-
 semver@7.7.4, semver@^7.3.5, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
@@ -4044,7 +3936,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript-eslint@^8.54.0, typescript-eslint@^8.55.0:
+typescript-eslint@^8.54.0:
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.55.0.tgz#abae8295c5f0f82f816218113a46e89bc30c3de2"
   integrity sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==


### PR DESCRIPTION
## Summary

- Migrate `mulmocast-mcp` from standalone repository ([receptron/mulmocast-mcp](https://github.com/receptron/mulmocast-mcp), now archived) into `packages/mulmocast-mcp`
- Adapt `tsconfig.json` to use shared base config
- Adjust `package.json` for monorepo conventions (repository URL, homepage)
- Add `zod` dependency for `@modelcontextprotocol/sdk` peer requirement
- Fix lint error (`no-console`)

## User Prompt

- mulmocast-mcp を mulmocast-plus 以下に移動する
- 現在のレポジトリの README に移動した旨を追記してアーカイブ
- 移動先ではモノレポの他のパッケージと構成を合わせる

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn lint` passes
- [x] `yarn format` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)