### PR TITLE
chore: update dependencies to @mulmocast/types@2.1.38

### DIFF
--- a/packages/mulmocast-easy/package.json
+++ b/packages/mulmocast-easy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-easy",
-  "version": "2.1.37",
+  "version": "2.1.38",
   "description": "MulmoCast with bundled ffmpeg for easy installation",
   "type": "module",
   "main": "lib/index.js",
@@ -36,6 +36,6 @@
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
     "ffmpeg-ffprobe-static": "^6.1.2-rc.1",
-    "mulmocast": "^2.1.37"
+    "mulmocast": "^2.1.38"
   }
 }

--- a/packages/mulmocast-extended-types/package.json
+++ b/packages/mulmocast-extended-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/extended-types",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Type definitions and Zod schemas for MulmoScript ExtendedMulmoScript format",
   "type": "module",
   "main": "lib/index.js",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
-    "@mulmocast/types": "^2.1.35",
+    "@mulmocast/types": "^2.1.38",
     "zod": "^4.3.6"
   }
 }

--- a/packages/mulmocast-mcp/package.json
+++ b/packages/mulmocast-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP (Model Context Protocol) server for MulmoCast",
   "type": "module",
   "main": "lib/index.js",
@@ -35,8 +35,8 @@
   "homepage": "https://github.com/receptron/mulmocast-plus#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "dotenv": "^17.2.4",
-    "mulmocast": "^2.1.35",
+    "dotenv": "^17.3.1",
+    "mulmocast": "^2.1.38",
     "zod": "^4.3.6"
   },
   "engines": {

--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-preprocessor",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Preprocessor for MulmoScript",
   "type": "module",
   "main": "lib/index.js",
@@ -40,8 +40,8 @@
     "@graphai/openai_agent": "^2.0.9",
     "@graphai/vanilla": "^2.0.12",
     "@mulmocast/extended-types": "^0.3.0",
-    "@mulmocast/types": "^2.1.37",
-    "dotenv": "^17.2.4",
+    "@mulmocast/types": "^2.1.38",
+    "dotenv": "^17.3.1",
     "graphai": "^2.0.16",
     "yargs": "^18.0.0",
     "zod": "^4.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,7 +303,7 @@
   dependencies:
     google-gax "^5.0.0"
 
-"@google/genai@^1.38.0", "@google/genai@^1.40.0":
+"@google/genai@^1.38.0", "@google/genai@^1.41.0":
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.41.0.tgz#7ea7ec31aabacd16a9e78a0a8809372ef67f781f"
   integrity sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==
@@ -326,10 +326,10 @@
     "@anthropic-ai/sdk" "^0.71.0"
     "@graphai/llm_utils" "^2.0.3"
 
-"@graphai/browserless_agent@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@graphai/browserless_agent/-/browserless_agent-2.0.1.tgz#951e9800ef7c3d696f3b829347ac9d05ba4e4dc5"
-  integrity sha512-Uq7gikcA7lrK3xyZwKPx6au0VcMKXDHbzHjOkuBV/I0RDNWo3qApmF6pTVBVR49WtrKKloN2/a48+8IzPGefLg==
+"@graphai/browserless_agent@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@graphai/browserless_agent/-/browserless_agent-2.0.2.tgz#463841c3841007c99cf8deca3111c7110940cf36"
+  integrity sha512-wkSepomu+/8BOCfWegOgDmHUEm34Nx+FXxuVfu7aa3kAlelC5JaUDp8ql9Y9fiuiBv6XSTIx8VifgPsI81B/6g==
 
 "@graphai/gemini_agent@^2.0.5":
   version "2.0.5"
@@ -570,10 +570,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/types@^2.1.35", "@mulmocast/types@^2.1.37":
-  version "2.1.37"
-  resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.37.tgz#02c3305bc9a92f6637fdbfb21ca92c3abbf9dfc5"
-  integrity sha512-f1kHUUiVLaUUetOyEqvjtwz+ISzjSYmurkYXDL7pl4J4fHyRlasslBRqwiQHKKuknQmf1AzJQFM2FGk0sRw3lg==
+"@mulmocast/types@^2.1.38":
+  version "2.1.38"
+  resolved "https://registry.yarnpkg.com/@mulmocast/types/-/types-2.1.38.tgz#2591d3e5342eb136395329f442ad413aaf5a886b"
+  integrity sha512-w9VW4qNTpIxOtCsJbh3JGKykLnliBKqhuVTcrrinRqh9DrDvPn3Mcj8/CVNlkroBbXXJiEW9OsWkXEsjv72XnA==
   dependencies:
     zod "^4.3.5"
 
@@ -1232,10 +1232,10 @@ clipboard-image@^0.1.0:
   dependencies:
     run-jxa "^3.0.0"
 
-clipboardy@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-5.2.1.tgz#78f20b3b8ec2817774638d82efec68429fbeaa85"
-  integrity sha512-RWp4E/ivQAzgF4QSWA9sjeW+Bjo+U2SvebkDhNIfO7y65eGdXPUxMTdIKYsn+bxM3ItPHGm3e68Bv3fgQ3mARw==
+clipboardy@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-5.3.0.tgz#ce9fd3647482cdd9e8596c5717456d2e6fa6e4fe"
+  integrity sha512-EOei1RJTbqXbXhUBMGN8C/Pf+QIPrnDWx9ztlmcW5Hljqj/oVlPrlrDw2O4xh5ViHcvHX3+A0zBrCdcptKTaJA==
   dependencies:
     clipboard-image "^0.1.0"
     execa "^9.6.1"
@@ -1478,11 +1478,6 @@ dfa@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/dfa/-/dfa-1.2.0.tgz#96ac3204e2d29c49ea5b57af8d92c2ae12790657"
   integrity sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==
-
-dotenv@^17.2.4:
-  version "17.2.4"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.4.tgz#b5a0e2f015e0be287a5330a90bf0e804606504c2"
-  integrity sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==
 
 dotenv@^17.3.1:
   version "17.3.1"
@@ -2769,10 +2764,10 @@ macos-version@^6.0.0:
   dependencies:
     semver "^7.3.5"
 
-marked@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-17.0.1.tgz#9db34197ac145e5929572ee49ef701e37ee9b2e6"
-  integrity sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==
+marked@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-17.0.2.tgz#a103f82bed9653dd1d74c15f74107c84ddbe749d"
+  integrity sha512-s5HZGFQea7Huv5zZcAGhJLT3qLpAfnY7v7GWkICUr0+Wd5TFEtdlRR2XUL5Gg+RH7u2Df595ifrxR03mBaw7gA==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -2869,15 +2864,15 @@ ms@^2.0.0, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mulmocast@^2.1.35, mulmocast@^2.1.37:
-  version "2.1.37"
-  resolved "https://registry.yarnpkg.com/mulmocast/-/mulmocast-2.1.37.tgz#dd54543206b6be3c3c52feac5775665320d01a72"
-  integrity sha512-b+PKtziVcfGEOtuIHJhxCfWFBZyf9Vd3i5X8e4RDQgDaOY/p8ELReSmjyr9I6VY3AG4LbmLuH0BbrKcMCtExBg==
+mulmocast@^2.1.38:
+  version "2.1.38"
+  resolved "https://registry.yarnpkg.com/mulmocast/-/mulmocast-2.1.38.tgz#3a686727a7645c891f961ad4c0a9685fe98d7fad"
+  integrity sha512-sJpNzcN9LJLXyHkjez2swcP5H7PUJRTOtc1PP92hQYTyVeaXxbNy0cVoplNAC14OIvtWIQUgIm+NA42J7DyxGg==
   dependencies:
     "@google-cloud/text-to-speech" "^6.4.0"
-    "@google/genai" "^1.40.0"
+    "@google/genai" "^1.41.0"
     "@graphai/anthropic_agent" "^2.0.12"
-    "@graphai/browserless_agent" "^2.0.1"
+    "@graphai/browserless_agent" "^2.0.2"
     "@graphai/gemini_agent" "^2.0.5"
     "@graphai/groq_agent" "^2.0.2"
     "@graphai/input_agents" "^1.0.2"
@@ -2891,12 +2886,12 @@ mulmocast@^2.1.35, mulmocast@^2.1.37:
     "@mozilla/readability" "^0.6.0"
     "@tavily/core" "^0.5.11"
     archiver "^7.0.1"
-    clipboardy "^5.2.1"
-    dotenv "^17.2.4"
+    clipboardy "^5.3.0"
+    dotenv "^17.3.1"
     fluent-ffmpeg "^2.1.3"
     graphai "^2.0.16"
     jsdom "^28.0.0"
-    marked "^17.0.1"
+    marked "^17.0.2"
     mulmocast-vision "^1.0.8"
     ora "^9.3.0"
     puppeteer "^24.37.2"


### PR DESCRIPTION
## Summary
- Update `@mulmocast/types` to `^2.1.38` (adds `id` to `MulmoViewerBeat`)
- Update `mulmocast` to `^2.1.38`
- Publish all packages with bumped versions:
  - `@mulmocast/extended-types@0.3.1`
  - `mulmocast-preprocessor@0.5.2`
  - `mulmocast-mcp@1.0.2`
  - `mulmocast-easy@2.1.38`

## User Prompt
publish必要なものは、それぞれupdate & publish & commitをしていって、最後にPR -> mergeしてreleaseを。

🤖 Generated with [Claude Code](https://claude.com/claude-code)