### PR TITLE
refactor: context builder の引数型を ExtendedMulmoViewerData に変更

### DIFF
--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
+    },
+    "./context": {
+      "types": "./lib/context.d.ts",
+      "default": "./lib/context.js"
     }
   },
   "files": [

--- a/packages/mulmocast-preprocessor/src/context.ts
+++ b/packages/mulmocast-preprocessor/src/context.ts
@@ -1,3 +1,8 @@
 // Lightweight entry point for context-building utilities (no GraphAI dependency)
-export { buildScriptContent, buildBeatContent, buildScriptMetaContent, scriptToViewerData } from "./core/ai/llm.js";
-export { DEFAULT_INTERACTIVE_SYSTEM_PROMPT } from "./core/ai/command/query/prompts.js";
+export {
+  buildScriptContent,
+  buildBeatContent,
+  buildScriptMetaContent,
+  scriptToViewerData,
+  DEFAULT_INTERACTIVE_SYSTEM_PROMPT,
+} from "./core/ai/context-builder.js";

--- a/packages/mulmocast-preprocessor/src/context.ts
+++ b/packages/mulmocast-preprocessor/src/context.ts
@@ -1,0 +1,3 @@
+// Lightweight entry point for context-building utilities (no GraphAI dependency)
+export { buildScriptContent, buildBeatContent, buildScriptMetaContent, scriptToViewerData } from "./core/ai/llm.js";
+export { DEFAULT_INTERACTIVE_SYSTEM_PROMPT } from "./core/ai/command/query/prompts.js";

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -48,17 +48,8 @@ export const buildUserPrompt = (script: ExtendedMulmoScript, question: string): 
   return parts.join("\n");
 };
 
-/**
- * Default system prompt for interactive query
- */
-export const DEFAULT_INTERACTIVE_SYSTEM_PROMPT = `You are answering questions based on the content provided.
-- Answer based ONLY on the information in the provided content
-- If the answer cannot be found in the content, say so clearly
-- Be concise and direct in your answers
-- Do not make up information that is not in the content
-- You may reference previous conversation when answering follow-up questions
-- If references are available and the user asks for more details, mention which reference could provide more information
-- When you suggest fetching a reference for more details, include [SUGGEST_FETCH: <url>] in your response`;
+import { DEFAULT_INTERACTIVE_SYSTEM_PROMPT } from "../../context-builder.js";
+export { DEFAULT_INTERACTIVE_SYSTEM_PROMPT };
 
 /**
  * Default system prompt for interactive query with fetched content

--- a/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/query/prompts.ts
@@ -1,6 +1,6 @@
 import type { QueryOptions, ConversationMessage } from "../../../../types/query.js";
 import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
-import { getLanguageName, buildScriptContent } from "../../llm.js";
+import { getLanguageName, buildScriptContent, scriptToViewerData } from "../../llm.js";
 
 /**
  * Default system prompt for query
@@ -37,7 +37,7 @@ export const buildUserPrompt = (script: ExtendedMulmoScript, question: string): 
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)
-  parts.push(buildScriptContent(script));
+  parts.push(buildScriptContent(scriptToViewerData(script)));
 
   parts.push("---");
   parts.push("");
@@ -96,7 +96,7 @@ export const buildInteractiveUserPrompt = (script: ExtendedMulmoScript, question
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)
-  parts.push(buildScriptContent(script));
+  parts.push(buildScriptContent(scriptToViewerData(script)));
 
   parts.push("---");
   parts.push("");

--- a/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/command/summarize/prompts.ts
@@ -1,6 +1,6 @@
 import type { SummarizeOptions } from "../../../../types/summarize.js";
 import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
-import { getLanguageName, buildScriptContent } from "../../llm.js";
+import { getLanguageName, buildScriptContent, scriptToViewerData } from "../../llm.js";
 
 /**
  * Default system prompt for text summary
@@ -30,7 +30,7 @@ export const buildUserPrompt = (script: ExtendedMulmoScript, options: SummarizeO
   const parts: string[] = [];
 
   // Add common script content (title, language, sections with beats)
-  parts.push(buildScriptContent(script));
+  parts.push(buildScriptContent(scriptToViewerData(script)));
 
   // Add target length if specified
   if (options.targetLengthChars) {

--- a/packages/mulmocast-preprocessor/src/core/ai/context-builder.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/context-builder.ts
@@ -1,0 +1,169 @@
+import type { ExtendedMulmoScript, ExtendedMulmoViewerData, ExtendedMulmoViewerBeat } from "@mulmocast/extended-types";
+
+/**
+ * Default system prompt for interactive query
+ */
+export const DEFAULT_INTERACTIVE_SYSTEM_PROMPT = `You are answering questions based on the content provided.
+- Answer based ONLY on the information in the provided content
+- If the answer cannot be found in the content, say so clearly
+- Be concise and direct in your answers
+- Do not make up information that is not in the content
+- You may reference previous conversation when answering follow-up questions
+- If references are available and the user asks for more details, mention which reference could provide more information
+- When you suggest fetching a reference for more details, include [SUGGEST_FETCH: <url>] in your response`;
+
+/**
+ * Build beat content including metadata
+ */
+export const buildBeatContent = (beat: ExtendedMulmoViewerBeat, index: number): string => {
+  const lines: string[] = [];
+
+  // Main text
+  const text = beat.text || "";
+  if (!text.trim()) return "";
+
+  lines.push(`[${index}] ${text}`);
+
+  // Add metadata if available
+  const meta = beat.meta;
+  if (meta) {
+    // Tags for categorization
+    if (meta.tags && meta.tags.length > 0) {
+      lines.push(`  Tags: ${meta.tags.join(", ")}`);
+    }
+    // Context provides additional information not in the text
+    if (meta.context) {
+      lines.push(`  Context: ${meta.context}`);
+    }
+    // Keywords highlight important terms
+    if (meta.keywords && meta.keywords.length > 0) {
+      lines.push(`  Keywords: ${meta.keywords.join(", ")}`);
+    }
+    // Expected questions this beat can answer
+    if (meta.expectedQuestions && meta.expectedQuestions.length > 0) {
+      lines.push(`  Can answer: ${meta.expectedQuestions.join("; ")}`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+/**
+ * Build script-level metadata section
+ */
+export const buildScriptMetaContent = (data: ExtendedMulmoViewerData): string => {
+  const meta = data.scriptMeta;
+  if (!meta) return "";
+
+  const lines: string[] = [];
+
+  // Background info
+  if (meta.background) {
+    lines.push(`Background: ${meta.background}`);
+  }
+
+  // Audience and prerequisites
+  if (meta.audience) {
+    lines.push(`Target audience: ${meta.audience}`);
+  }
+  if (meta.prerequisites && meta.prerequisites.length > 0) {
+    lines.push(`Prerequisites: ${meta.prerequisites.join(", ")}`);
+  }
+
+  // Goals
+  if (meta.goals && meta.goals.length > 0) {
+    lines.push(`Goals: ${meta.goals.join("; ")}`);
+  }
+
+  // Keywords
+  if (meta.keywords && meta.keywords.length > 0) {
+    lines.push(`Keywords: ${meta.keywords.join(", ")}`);
+  }
+
+  // References
+  if (meta.references && meta.references.length > 0) {
+    lines.push("References:");
+    meta.references.forEach((ref) => {
+      const title = ref.title || ref.url;
+      const desc = ref.description ? ` - ${ref.description}` : "";
+      lines.push(`  - [${ref.type || "web"}] ${title}: ${ref.url}${desc}`);
+    });
+  }
+
+  // FAQ
+  if (meta.faq && meta.faq.length > 0) {
+    lines.push("FAQ:");
+    meta.faq.forEach((faq) => {
+      lines.push(`  Q: ${faq.question}`);
+      lines.push(`  A: ${faq.answer}`);
+    });
+  }
+
+  // Author info
+  if (meta.author) {
+    lines.push(`Author: ${meta.author}`);
+  }
+
+  return lines.length > 0 ? lines.join("\n") : "";
+};
+
+/**
+ * Convert ExtendedMulmoScript to ExtendedMulmoViewerData (extract only needed fields)
+ */
+export const scriptToViewerData = (script: ExtendedMulmoScript): ExtendedMulmoViewerData => {
+  return {
+    beats: script.beats.map((b) => ({
+      text: b.text,
+      meta: b.meta,
+      variants: b.variants,
+      id: b.id,
+    })),
+    title: script.title,
+    lang: script.lang,
+    scriptMeta: script.scriptMeta,
+    outputProfiles: script.outputProfiles,
+  };
+};
+
+/**
+ * Build script content for user prompt (common part)
+ */
+export const buildScriptContent = (data: ExtendedMulmoViewerData): string => {
+  const parts: string[] = [];
+
+  // Add script title and language
+  parts.push(`# Script: ${data.title}`);
+  parts.push(`Language: ${data.lang}`);
+  parts.push("");
+
+  // Add script-level metadata
+  const scriptMetaContent = buildScriptMetaContent(data);
+  if (scriptMetaContent) {
+    parts.push("## About this content");
+    parts.push(scriptMetaContent);
+    parts.push("");
+  }
+
+  // Collect all content from beats grouped by section
+  const sections = new Map<string, string[]>();
+
+  data.beats.forEach((beat, index) => {
+    const content = buildBeatContent(beat, index);
+    if (!content) return;
+
+    const section = beat.meta?.section || "main";
+    if (!sections.has(section)) {
+      sections.set(section, []);
+    }
+    sections.get(section)!.push(content);
+  });
+
+  // Output by section
+  sections.forEach((contents, section) => {
+    parts.push(`## Section: ${section}`);
+    contents.forEach((c) => parts.push(c));
+    parts.push("");
+  });
+
+  return parts.join("\n");
+};

--- a/packages/mulmocast-preprocessor/src/core/ai/llm.ts
+++ b/packages/mulmocast-preprocessor/src/core/ai/llm.ts
@@ -7,9 +7,12 @@ import { anthropicAgent } from "@graphai/anthropic_agent";
 import { groqAgent } from "@graphai/groq_agent";
 import { geminiAgent } from "@graphai/gemini_agent";
 
-import type { ExtendedMulmoScript, ExtendedMulmoViewerData, ExtendedMulmoViewerBeat } from "@mulmocast/extended-types";
+import type { ExtendedMulmoScript } from "@mulmocast/extended-types";
 import type { LLMProvider } from "../../types/summarize.js";
 import { filterBySection, filterByTags } from "../preprocessing/filter.js";
+
+// Re-export pure context-building functions (no GraphAI dependency)
+export { buildBeatContent, buildScriptMetaContent, buildScriptContent, scriptToViewerData } from "./context-builder.js";
 
 dotenv.config({ quiet: true });
 
@@ -141,162 +144,6 @@ export const getLanguageName = (langCode: string): string => {
     ru: "Russian",
   };
   return langMap[langCode] || langCode;
-};
-
-/**
- * Build beat content including metadata
- */
-export const buildBeatContent = (beat: ExtendedMulmoViewerBeat, index: number): string => {
-  const lines: string[] = [];
-
-  // Main text
-  const text = beat.text || "";
-  if (!text.trim()) return "";
-
-  lines.push(`[${index}] ${text}`);
-
-  // Add metadata if available
-  const meta = beat.meta;
-  if (meta) {
-    // Tags for categorization
-    if (meta.tags && meta.tags.length > 0) {
-      lines.push(`  Tags: ${meta.tags.join(", ")}`);
-    }
-    // Context provides additional information not in the text
-    if (meta.context) {
-      lines.push(`  Context: ${meta.context}`);
-    }
-    // Keywords highlight important terms
-    if (meta.keywords && meta.keywords.length > 0) {
-      lines.push(`  Keywords: ${meta.keywords.join(", ")}`);
-    }
-    // Expected questions this beat can answer
-    if (meta.expectedQuestions && meta.expectedQuestions.length > 0) {
-      lines.push(`  Can answer: ${meta.expectedQuestions.join("; ")}`);
-    }
-  }
-
-  return lines.join("\n");
-};
-
-/**
- * Build script-level metadata section
- */
-export const buildScriptMetaContent = (data: ExtendedMulmoViewerData): string => {
-  const meta = data.scriptMeta;
-  if (!meta) return "";
-
-  const lines: string[] = [];
-
-  // Background info
-  if (meta.background) {
-    lines.push(`Background: ${meta.background}`);
-  }
-
-  // Audience and prerequisites
-  if (meta.audience) {
-    lines.push(`Target audience: ${meta.audience}`);
-  }
-  if (meta.prerequisites && meta.prerequisites.length > 0) {
-    lines.push(`Prerequisites: ${meta.prerequisites.join(", ")}`);
-  }
-
-  // Goals
-  if (meta.goals && meta.goals.length > 0) {
-    lines.push(`Goals: ${meta.goals.join("; ")}`);
-  }
-
-  // Keywords
-  if (meta.keywords && meta.keywords.length > 0) {
-    lines.push(`Keywords: ${meta.keywords.join(", ")}`);
-  }
-
-  // References
-  if (meta.references && meta.references.length > 0) {
-    lines.push("References:");
-    meta.references.forEach((ref) => {
-      const title = ref.title || ref.url;
-      const desc = ref.description ? ` - ${ref.description}` : "";
-      lines.push(`  - [${ref.type || "web"}] ${title}: ${ref.url}${desc}`);
-    });
-  }
-
-  // FAQ
-  if (meta.faq && meta.faq.length > 0) {
-    lines.push("FAQ:");
-    meta.faq.forEach((faq) => {
-      lines.push(`  Q: ${faq.question}`);
-      lines.push(`  A: ${faq.answer}`);
-    });
-  }
-
-  // Author info
-  if (meta.author) {
-    lines.push(`Author: ${meta.author}`);
-  }
-
-  return lines.length > 0 ? lines.join("\n") : "";
-};
-
-/**
- * Convert ExtendedMulmoScript to ExtendedMulmoViewerData (extract only needed fields)
- */
-export const scriptToViewerData = (script: ExtendedMulmoScript): ExtendedMulmoViewerData => {
-  return {
-    beats: script.beats.map((b) => ({
-      text: b.text,
-      meta: b.meta,
-      variants: b.variants,
-      id: b.id,
-    })),
-    title: script.title,
-    lang: script.lang,
-    scriptMeta: script.scriptMeta,
-    outputProfiles: script.outputProfiles,
-  };
-};
-
-/**
- * Build script content for user prompt (common part)
- */
-export const buildScriptContent = (data: ExtendedMulmoViewerData): string => {
-  const parts: string[] = [];
-
-  // Add script title and language
-  parts.push(`# Script: ${data.title}`);
-  parts.push(`Language: ${data.lang}`);
-  parts.push("");
-
-  // Add script-level metadata
-  const scriptMetaContent = buildScriptMetaContent(data);
-  if (scriptMetaContent) {
-    parts.push("## About this content");
-    parts.push(scriptMetaContent);
-    parts.push("");
-  }
-
-  // Collect all content from beats grouped by section
-  const sections = new Map<string, string[]>();
-
-  data.beats.forEach((beat, index) => {
-    const content = buildBeatContent(beat, index);
-    if (!content) return;
-
-    const section = beat.meta?.section || "main";
-    if (!sections.has(section)) {
-      sections.set(section, []);
-    }
-    sections.get(section)!.push(content);
-  });
-
-  // Output by section
-  sections.forEach((contents, section) => {
-    parts.push(`## Section: ${section}`);
-    contents.forEach((c) => parts.push(c));
-    parts.push("");
-  });
-
-  return parts.join("\n");
 };
 
 /**


### PR DESCRIPTION
## Summary

mulmocast-preprocessor のコンテキストビルダー関数（`buildScriptContent`, `buildBeatContent`, `buildScriptMetaContent`）の引数型を `ExtendedMulmoScript` から `ExtendedMulmoViewerData` に変更し、ブラウザ向け軽量エントリポイント `mulmocast-preprocessor/context` を追加。

## 背景と目的

mulmocast-slides の Q&A Chat 機能（`qa-context.ts`）に、preprocessor の `buildScriptContent` / `buildBeatContent` / `buildScriptMetaContent` とほぼ同一のコンテキストビルダーが**重複実装**されている。system prompt（`DEFAULT_INTERACTIVE_SYSTEM_PROMPT`）も重複。

しかし、slides 側は `ExtendedMulmoViewerData` 型を使用し、preprocessor 側は `ExtendedMulmoScript` 型を受け取るため、そのままでは共通化できない。

### なぜ ExtendedMulmoViewerData に揃えるのか

- `ExtendedMulmoViewerData` は全フィールドが optional でシンプル（ダミー値不要）
- slides 側は**変換不要で直接渡せる**
- `buildScriptContent` が使うフィールド（`title`, `lang`, `beats[].text`, `beats[].meta`, `scriptMeta`）は両型で同一構造
- preprocessor 内部では `scriptToViewerData()` 変換関数で `ExtendedMulmoScript → ExtendedMulmoViewerData` に変換してから渡す

### 全体の流れ（2リポにまたがるリファクタリング）

1. **本 PR（preprocessor）**: 引数型変更 + `./context` サブパスエクスポート追加
2. **後続 PR（mulmocast-slides）**: `qa-context.ts` を削除し、`mulmocast-preprocessor/context` からの import に置換

## 変更内容

### `src/core/ai/llm.ts`
- `buildBeatContent`: 引数型を `ExtendedMulmoScript["beats"][number]` → `ExtendedMulmoViewerBeat` に変更、export 追加
- `buildScriptMetaContent`: 引数型を `ExtendedMulmoScript` → `ExtendedMulmoViewerData` に変更、export 追加
- `buildScriptContent`: 引数型を `ExtendedMulmoScript` → `ExtendedMulmoViewerData` に変更
- `scriptToViewerData()`: 新規追加。`ExtendedMulmoScript` から必要なフィールドのみ抽出して `ExtendedMulmoViewerData` に変換

### `src/core/ai/command/query/prompts.ts`, `src/core/ai/command/summarize/prompts.ts`
- `buildScriptContent(script)` → `buildScriptContent(scriptToViewerData(script))` に変更

### `src/context.ts` (新規)
- GraphAI 依存なしの軽量エントリポイント
- `buildScriptContent`, `buildBeatContent`, `buildScriptMetaContent`, `scriptToViewerData`, `DEFAULT_INTERACTIVE_SYSTEM_PROMPT` をエクスポート

### `package.json`
- `exports` に `"./context"` サブパスエクスポート追加

## Test plan

- [x] `yarn build` — ビルド成功、`lib/context.js` と `lib/context.d.ts` が生成されること
- [x] `yarn test` — 既存 71 テスト全パス
- [x] `yarn lint` — エラーなし（既存の warning のみ）

## User Prompt

- mulmocast-preprocessor のコンテキストビルダー（`buildScriptContent` 等）の引数型を `ExtendedMulmoViewerData` に変更し、slides 側と共通利用できるようにする
- preprocessor 内部では `scriptToViewerData()` 変換関数で既存コードの互換性を維持
- ブラウザ向け軽量エントリポイント `mulmocast-preprocessor/context` を追加（GraphAI 依存なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes context-building utilities and a default interactive system prompt for more consistent AI-driven responses.
  * Adds a utility to convert scripts into a viewer-friendly format, improving prompt accuracy.

* **Refactor**
  * Reorganized context and prompt logic so both interactive and non-interactive flows share the same content generation path, simplifying maintenance and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->