### PR TITLE
release: mulmocast-preprocessor@0.6.0

### DIFF
--- a/packages/mulmocast-preprocessor/package.json
+++ b/packages/mulmocast-preprocessor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast-preprocessor",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Preprocessor for MulmoScript",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0
- Breaking: preprocessing utilities moved to `@mulmocast/script-utils`
- Breaking: `./context` subpath export removed
- Consumers should import `processScript`, `filterBySection`, `filterByTags`, etc. from `@mulmocast/script-utils`

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (55/55)
- [ ] `npm publish` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->