### PR TITLE
chore: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -31,7 +31,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
@@ -54,25 +54,25 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
     - name: Cache Puppeteer (Linux)
       if: runner.os == 'Linux'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}
     - name: Cache Puppeteer (macOS)
       if: runner.os == 'macOS'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/Library/Caches/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}
     - name: Cache Puppeteer (Windows)
       if: runner.os == 'Windows'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~\AppData\Local\puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- **actions/cache v4 → v5**: Node.js 20 deprecation warning の解消

## Test plan
- [ ] CI で Node.js 20 deprecation warning が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)