### PR TITLE
chore: bump actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -106,7 +106,7 @@ jobs:
       working-directory: packages/mulmocast-easy
       run: npx tsx src/cli/bin.ts movie test/test_ffmpeg.json
     - name: Upload generated media
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: generatedmedia-${{ matrix.os }}-${{ matrix.node-version }}
         path: packages/mulmocast-easy/output/


### PR DESCRIPTION
## Summary
Bumps `actions/upload-artifact` from `@v4` to `@v7` (current latest) in `.github/workflows/pull_request.yaml`.

## Items to Confirm / Review
- Mechanical version bump only. CI run on this PR validates the artifact upload step still works under v7.

## User Prompt
`actions/upload-artifact@v4` を最新（v7）にバージョンアップ。`~/ss/llm` 配下の重複しない自リポ + GUIChatPlugins 配下を対象に、main を最新化してから新ブランチで実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
